### PR TITLE
Initialise genesis QC if no highest QC exists

### DIFF
--- a/radixdlt/src/main/java/com/radixdlt/consensus/VertexStore.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/VertexStore.java
@@ -17,7 +17,10 @@
 
 package com.radixdlt.consensus;
 
+import com.google.inject.Inject;
+
 import java.util.HashSet;
+import java.util.Optional;
 
 /**
  * Manages the BFT Vertex chain
@@ -26,6 +29,7 @@ public final class VertexStore {
 	private final HashSet<Vertex> vertices = new HashSet<>();
 	private QuorumCertificate highestQC = null;
 
+	@Inject
 	public VertexStore() {
 	}
 
@@ -44,7 +48,7 @@ public final class VertexStore {
 		vertices.add(vertex);
 	}
 
-	public QuorumCertificate getHighestQC() {
-		return highestQC;
+	public Optional<QuorumCertificate> getHighestQC() {
+		return Optional.ofNullable(this.highestQC);
 	}
 }


### PR DESCRIPTION
Instead of using a null QC use a proper genesis QC (with all zeros as rounds & id) as the first QC in our tree.