### PR TITLE
Implement API to Start BFT via RPC call

### DIFF
--- a/docker/config/default.config.envsubst
+++ b/docker/config/default.config.envsubst
@@ -26,6 +26,7 @@ debug.profiler=$RADIXDLT_DEBUG_PROFILER
 consensus.fixed_quorum_size=$RADIXDLT_CONSENSUS_FIXED_QUORUM_SIZE
 consensus.pacemaker_timeout_millis=$RADIXDLT_PACEMAKER_TIMEOUT_MILLIS
 consensus.fixed_node_count=$RADIXDLT_CONSENSUS_FIXED_NODE_COUNT
+consensus.start_on_boot=$RADIXDLT_CONSENSUS_START_ON_BOOT
 
 # Host IP
 host.ip=$RADIXDLT_HOST_IP_ADDRESS

--- a/radixdlt/src/integration/java/com/radixdlt/consensus/simulation/BFTNetworkSimulation.java
+++ b/radixdlt/src/integration/java/com/radixdlt/consensus/simulation/BFTNetworkSimulation.java
@@ -183,7 +183,7 @@ public class BFTNetworkSimulation {
 	}
 
 	public void start() {
-		this.bfts.forEach((e, bft) -> bft.start());
+		this.bfts.values().forEach(ChainedBFT::start);
 	}
 
 	public TestEventCoordinatorNetwork getUnderlyingNetwork() {

--- a/radixdlt/src/integration/java/com/radixdlt/consensus/simulation/BFTTest.java
+++ b/radixdlt/src/integration/java/com/radixdlt/consensus/simulation/BFTTest.java
@@ -158,10 +158,8 @@ public class BFTTest {
 			.build();
 		BFTNetworkSimulation bftNetwork =  new BFTNetworkSimulation(nodes, network, pacemakerTimeout);
 		List<Completable> assertions = this.checks.stream().map(c -> c.check(bftNetwork)).collect(Collectors.toList());
-		Completable.mergeArray(
-			bftNetwork.processBFT().flatMapCompletable(e -> Completable.complete()),
-			Completable.merge(assertions)
-		)
+		Completable.merge(assertions)
+			.doOnSubscribe(d -> bftNetwork.start())
 			.blockingAwait(duration, timeUnit);
 	}
 }

--- a/radixdlt/src/integration/java/com/radixdlt/consensus/simulation/asynchronous/CrashFaultNetworkTest.java
+++ b/radixdlt/src/integration/java/com/radixdlt/consensus/simulation/asynchronous/CrashFaultNetworkTest.java
@@ -94,8 +94,8 @@ public class CrashFaultNetworkTest {
 			.doAfterSuccess(v -> System.out.println("Committed " + v))
 			.toObservable();
 
-		bftNetwork.processBFT().takeUntil(committed)
-			.blockingSubscribe();
+		bftNetwork.start();
+		committed.blockingSubscribe();
 	}
 
 	/**
@@ -197,7 +197,8 @@ public class CrashFaultNetworkTest {
 		List<Observable<Object>> checks = Arrays.asList(
 			correctCommitCheck, progressCheck, correctTimeoutCheck, directProposalsCheck, gapProposalsCheck
 		);
-		Observable.mergeArray(bftNetwork.processBFT(), Observable.merge(checks))
+		bftNetwork.start();
+		Observable.merge(checks)
 			.take(time, timeUnit)
 			.blockingSubscribe();
 	}
@@ -278,7 +279,8 @@ public class CrashFaultNetworkTest {
 			.map(o -> o);
 
 		List<Observable<Object>> checks = Arrays.asList(correctCommitCheck, progressCheck, seducer);
-		Observable.mergeArray(bftNetwork.processBFT(), Observable.merge(checks))
+		bftNetwork.start();
+		Observable.merge(checks)
 			.take(time, timeUnit)
 			.blockingSubscribe();
 	}

--- a/radixdlt/src/main/java/com/radixdlt/consensus/ChainedBFT.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/ChainedBFT.java
@@ -30,7 +30,7 @@ import io.reactivex.rxjava3.schedulers.Schedulers;
 import java.util.concurrent.Executors;
 
 /**
- * Subscription Manager (Start/Stop0 to the processing of BFT events under
+ * Subscription Manager (Start/Stop) to the processing of BFT events under
  * a single BFT node instance
  */
 public final class ChainedBFT {

--- a/radixdlt/src/main/java/com/radixdlt/consensus/ChainedBFT.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/ChainedBFT.java
@@ -25,13 +25,13 @@ import com.radixdlt.consensus.validators.ValidatorSet;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Scheduler;
+import io.reactivex.rxjava3.observables.ConnectableObservable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
-import java.util.Objects;
 import java.util.concurrent.Executors;
 
 /**
- * A three-chain BFT. The inputs are events via rx streams from a pacemaker and
- * a network.
+ * Subscription Manager (Start/Stop0 to the processing of BFT events under
+ * a single BFT node instance
  */
 public final class ChainedBFT {
 	public enum EventType {
@@ -58,12 +58,7 @@ public final class ChainedBFT {
 		}
 	}
 
-	private final EventCoordinatorNetworkRx network;
-	private final PacemakerRx pacemakerRx;
-	private final EpochRx epochRx;
-	private final EpochManager epochManager;
-
-	private final Scheduler singleThreadScheduler = Schedulers.from(Executors.newSingleThreadExecutor());
+	private final ConnectableObservable<Event> events;
 
 	@Inject
 	public ChainedBFT(
@@ -72,10 +67,34 @@ public final class ChainedBFT {
 		PacemakerRx pacemakerRx,
 		EpochManager epochManager
 	) {
-		this.pacemakerRx = Objects.requireNonNull(pacemakerRx);
-		this.network = Objects.requireNonNull(network);
-		this.epochRx = Objects.requireNonNull(epochRx);
-		this.epochManager = Objects.requireNonNull(epochManager);
+		final Scheduler singleThreadScheduler = Schedulers.from(Executors.newSingleThreadExecutor());
+		final Observable<ValidatorSet> epochEvents = epochRx.epochs()
+			.publish()
+			.autoConnect(2);
+
+		final Observable<Event> epochs = epochEvents
+			.map(o -> new Event(EventType.EPOCH, o));
+
+		final Observable<EventCoordinator> eventCoordinators = epochEvents
+			.map(epochManager::nextEpoch)
+			.startWithItem(epochManager.start())
+			.doOnNext(EventCoordinator::start)
+			.replay(1)
+			.autoConnect();
+
+		// Need to ensure that first event coordinator is emitted otherwise we may not process
+		// initial events due to the .withLatestFrom() drops events
+		final Completable firstEventCoordinator = Completable.fromSingle(eventCoordinators.firstOrError());
+		final Observable<Object> eventCoordinatorEvents = Observable.merge(
+			pacemakerRx.localTimeouts().observeOn(singleThreadScheduler),
+			network.consensusEvents().observeOn(singleThreadScheduler),
+			network.rpcRequests().observeOn(singleThreadScheduler)
+		);
+		final Observable<Event> ecMessages = firstEventCoordinator.andThen(
+			eventCoordinatorEvents.withLatestFrom(eventCoordinators, this::processEvent)
+		);
+
+		this.events = Observable.merge(epochs, ecMessages).publish();
 	}
 
 	private Event processEvent(Object msg, EventCoordinator eventCoordinator) {
@@ -102,41 +121,22 @@ public final class ChainedBFT {
 		return new Event(eventType, msg);
 	}
 
+	/**
+	 * Starts processing events. This call is idempotent in that multiple
+	 * calls will not affect execution, only one event handling stream will ever
+	 * occur.
+	 */
+	public void start() {
+		this.events.connect();
+	}
 
 	/**
-	 * Returns a cold observable which when subscribed to begins consuming
-	 * and processing bft events. Does not begin processing until the observable
-	 * is subscribed to.
+	 * For testing primarily, a way to retrieve events which have been
+	 * processed.
 	 *
-	 * @return observable of the events which are being processed
+	 * @return hot observable of the events which are being processed
 	 */
-	public Observable<Event> processEvents() {
-		final Observable<ValidatorSet> epochEvents = this.epochRx.epochs()
-			.publish()
-			.autoConnect(2);
-
-		final Observable<Event> epochs = epochEvents
-			.map(o -> new Event(EventType.EPOCH, o));
-
-		final Observable<EventCoordinator> eventCoordinators = epochEvents
-			.map(epochManager::nextEpoch)
-			.startWithItem(epochManager.start())
-			.doOnNext(EventCoordinator::start)
-			.replay(1)
-			.autoConnect();
-
-		// Need to ensure that first event coordinator is emitted otherwise we may not process
-		// initial events due to the .withLatestFrom() drops events
-		final Completable firstEventCoordinator = Completable.fromSingle(eventCoordinators.firstOrError());
-		final Observable<Object> eventCoordinatorEvents = Observable.merge(
-			this.pacemakerRx.localTimeouts().observeOn(this.singleThreadScheduler),
-			this.network.consensusEvents().observeOn(this.singleThreadScheduler),
-			this.network.rpcRequests().observeOn(this.singleThreadScheduler)
-		);
-		final Observable<Event> ecMessages = firstEventCoordinator.andThen(
-			eventCoordinatorEvents.withLatestFrom(eventCoordinators, this::processEvent)
-		);
-
-		return Observable.merge(epochs, ecMessages);
+	public Observable<Event> events() {
+		return this.events;
 	}
 }

--- a/radixdlt/src/main/java/org/radix/Radix.java
+++ b/radixdlt/src/main/java/org/radix/Radix.java
@@ -145,17 +145,20 @@ public final class Radix
 		// Start mempool receiver
 		globalInjector.getInjector().getInstance(MempoolReceiver.class).start();
 
+		final ChainedBFT bft = globalInjector.getInjector().getInstance(ChainedBFT.class);
 		// start API services
-		ChainedBFT bft = globalInjector.getInjector().getInstance(ChainedBFT.class);
-		bft.start();
-
 		SubmissionControl submissionControl = globalInjector.getInjector().getInstance(SubmissionControl.class);
 		AtomToBinaryConverter atomToBinaryConverter = globalInjector.getInjector().getInstance(AtomToBinaryConverter.class);
 		LedgerEntryStore store = globalInjector.getInjector().getInstance(LedgerEntryStore.class);
-		RadixHttpServer httpServer = new RadixHttpServer(store, submissionControl, atomToBinaryConverter, universe, serialization, properties, localSystem, addressBook);
+		RadixHttpServer httpServer = new RadixHttpServer(bft, store, submissionControl, atomToBinaryConverter, universe, serialization, properties, localSystem, addressBook);
 		httpServer.start(properties);
 
-		log.info("Node '{}' started successfully", localSystem.getNID());
+		if (properties.get("consensus.start_on_boot", true)) {
+			bft.start();
+			log.info("Node '{}' started successfully", localSystem.getNID());
+		} else {
+			log.info("Node '{}' ready, waiting for start signal", localSystem.getNID());
+		}
 	}
 
 	private static void dumpExecutionLocation() {

--- a/radixdlt/src/main/java/org/radix/Radix.java
+++ b/radixdlt/src/main/java/org/radix/Radix.java
@@ -19,6 +19,7 @@ package org.radix;
 
 import com.radixdlt.DefaultSerialization;
 import com.radixdlt.consensus.ChainedBFT;
+import com.radixdlt.consensus.ChainedBFT.Event;
 import com.radixdlt.mempool.MempoolReceiver;
 import com.radixdlt.mempool.SubmissionControl;
 import com.radixdlt.middleware2.converters.AtomToBinaryConverter;
@@ -32,6 +33,7 @@ import com.radixdlt.store.LedgerEntryStore;
 import com.radixdlt.universe.Universe;
 import com.radixdlt.utils.Bytes;
 
+import io.reactivex.rxjava3.observables.ConnectableObservable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.commons.cli.ParseException;
@@ -145,15 +147,7 @@ public final class Radix
 
 		// start API services
 		ChainedBFT bft = globalInjector.getInjector().getInstance(ChainedBFT.class);
-		bft.processEvents()
-			.subscribe(
-				event -> {
-				},
-				e -> {
-					log.error("BFT Unexpected Error", e);
-					System.exit(-1);
-				}
-			);
+		bft.start();
 
 		SubmissionControl submissionControl = globalInjector.getInjector().getInstance(SubmissionControl.class);
 		AtomToBinaryConverter atomToBinaryConverter = globalInjector.getInjector().getInstance(AtomToBinaryConverter.class);

--- a/radixdlt/src/main/java/org/radix/Radix.java
+++ b/radixdlt/src/main/java/org/radix/Radix.java
@@ -19,7 +19,6 @@ package org.radix;
 
 import com.radixdlt.DefaultSerialization;
 import com.radixdlt.consensus.ChainedBFT;
-import com.radixdlt.consensus.ChainedBFT.Event;
 import com.radixdlt.mempool.MempoolReceiver;
 import com.radixdlt.mempool.SubmissionControl;
 import com.radixdlt.middleware2.converters.AtomToBinaryConverter;
@@ -33,7 +32,6 @@ import com.radixdlt.store.LedgerEntryStore;
 import com.radixdlt.universe.Universe;
 import com.radixdlt.utils.Bytes;
 
-import io.reactivex.rxjava3.observables.ConnectableObservable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.commons.cli.ParseException;

--- a/radixdlt/src/main/java/org/radix/api/http/RadixHttpServer.java
+++ b/radixdlt/src/main/java/org/radix/api/http/RadixHttpServer.java
@@ -17,6 +17,7 @@
 
 package org.radix.api.http;
 
+import com.radixdlt.consensus.ChainedBFT;
 import com.radixdlt.mempool.SubmissionControl;
 import com.radixdlt.middleware2.converters.AtomToBinaryConverter;
 import com.radixdlt.network.addressbook.AddressBook;
@@ -79,6 +80,7 @@ public final class RadixHttpServer {
 	private final Serialization serialization;
 
 	public RadixHttpServer(
+		ChainedBFT chainedBFT,
 		LedgerEntryStore store,
 		SubmissionControl submissionControl,
 		AtomToBinaryConverter atomToBinaryConverter,
@@ -95,6 +97,7 @@ public final class RadixHttpServer {
 		this.peers = new ConcurrentHashMap<>();
 		this.atomsService = new AtomsService(store, submissionControl, atomToBinaryConverter);
 		this.jsonRpcServer = new RadixJsonRpcServer(
+			chainedBFT,
 			serialization,
 			store,
 			atomsService,

--- a/radixdlt/src/main/java/org/radix/api/jsonrpc/RadixJsonRpcServer.java
+++ b/radixdlt/src/main/java/org/radix/api/jsonrpc/RadixJsonRpcServer.java
@@ -18,6 +18,7 @@
 package org.radix.api.jsonrpc;
 
 import com.google.common.io.CharStreams;
+import com.radixdlt.consensus.ChainedBFT;
 import com.radixdlt.identifiers.RadixAddress;
 import com.radixdlt.store.SearchCursor;
 import com.radixdlt.store.StoreIndex;
@@ -79,24 +80,33 @@ public final class RadixJsonRpcServer {
 	private final AddressBook addressBook;
 	private final Universe universe;
 
-	public RadixJsonRpcServer(Serialization serialization,
-	                          LedgerEntryStore ledger,
-	                          AtomsService atomsService,
-	                          Schema atomSchema,
-	                          LocalSystem localSystem,
-	                          AddressBook addressBook,
-	                          Universe universe) {
-		this(serialization, ledger, atomsService, atomSchema, localSystem, addressBook, universe, DEFAULT_MAX_REQUEST_SIZE);
+	private final ChainedBFT chainedBFT;
+
+	public RadixJsonRpcServer(
+		ChainedBFT chainedBFT,
+		Serialization serialization,
+		LedgerEntryStore ledger,
+		AtomsService atomsService,
+		Schema atomSchema,
+		LocalSystem localSystem,
+		AddressBook addressBook,
+		Universe universe
+	) {
+		this(chainedBFT, serialization, ledger, atomsService, atomSchema, localSystem, addressBook, universe, DEFAULT_MAX_REQUEST_SIZE);
 	}
 
-	public RadixJsonRpcServer(Serialization serialization,
-	                          LedgerEntryStore ledger,
-	                          AtomsService atomsService,
-	                          Schema atomSchema,
-	                          LocalSystem localSystem,
-	                          AddressBook addressBook,
-	                          Universe universe,
-	                          long maxRequestSizeBytes) {
+	public RadixJsonRpcServer(
+		ChainedBFT chainedBFT,
+		Serialization serialization,
+		LedgerEntryStore ledger,
+		AtomsService atomsService,
+		Schema atomSchema,
+		LocalSystem localSystem,
+		AddressBook addressBook,
+		Universe universe,
+		long maxRequestSizeBytes
+	) {
+		this.chainedBFT = Objects.requireNonNull(chainedBFT);
 		this.serialization = Objects.requireNonNull(serialization);
 		this.ledger = Objects.requireNonNull(ledger);
 		this.atomsService = Objects.requireNonNull(atomsService);
@@ -157,6 +167,11 @@ public final class RadixJsonRpcServer {
 			final String method = jsonRpcRequest.getString("method");
 			final Object paramsObject = jsonRpcRequest.get("params");
 			switch (method) {
+				case "BFT.start":
+					chainedBFT.start();
+					result = new JSONObject()
+                        .put("response", "success");
+					break;
 				case "Ledger.getAtom":
 					if (!(paramsObject instanceof JSONObject)) {
 						return JsonRpcUtil.errorResponse(id, -32000, "params should be a JSONObject" , new JSONObject());

--- a/radixdlt/src/main/java/org/radix/api/jsonrpc/RadixJsonRpcServer.java
+++ b/radixdlt/src/main/java/org/radix/api/jsonrpc/RadixJsonRpcServer.java
@@ -170,7 +170,7 @@ public final class RadixJsonRpcServer {
 				case "BFT.start":
 					chainedBFT.start();
 					result = new JSONObject()
-                        .put("response", "success");
+						.put("response", "success");
 					break;
 				case "Ledger.getAtom":
 					if (!(paramsObject instanceof JSONObject)) {

--- a/radixdlt/src/test/java/org/radix/api/jsonrpc/RadixJsonRpcServerTest.java
+++ b/radixdlt/src/test/java/org/radix/api/jsonrpc/RadixJsonRpcServerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.radixdlt.consensus.ChainedBFT;
 import com.radixdlt.store.LedgerEntryStore;
 import com.radixdlt.universe.Universe;
 import org.everit.json.schema.Schema;
@@ -40,6 +41,7 @@ public class RadixJsonRpcServerTest {
 		JSONObject request = new JSONObject();
 
 		RadixJsonRpcServer server = new RadixJsonRpcServer(
+			mock(ChainedBFT.class),
 			mock(Serialization.class),
 			mock(LedgerEntryStore.class),
 			mock(AtomsService.class),
@@ -70,6 +72,7 @@ public class RadixJsonRpcServerTest {
 		when(serializer.toJsonObject(any(), any())).thenAnswer(i -> i.getArguments()[0]);
 
 		RadixJsonRpcServer server = new RadixJsonRpcServer(
+			mock(ChainedBFT.class),
 			serializer,
 			mock(LedgerEntryStore.class),
 			mock(AtomsService.class),
@@ -90,6 +93,7 @@ public class RadixJsonRpcServerTest {
 	@Test
 	public void when_send_oversized_json_rpc_request_with__return_json_error_response() {
 		RadixJsonRpcServer server = new RadixJsonRpcServer(
+			mock(ChainedBFT.class),
 			mock(Serialization.class),
 			mock(LedgerEntryStore.class),
 			mock(AtomsService.class),


### PR DESCRIPTION
* Added `consensus.start_on_boot` config boolean property to determine whether to start consensus on boot
* Added `BFT.start` JSON-RPC call to manually start consensus