### PR TITLE
Bugfix/rpnv1 168 memory leak pendingvotes

### DIFF
--- a/radixdlt/src/integration/java/com/radixdlt/consensus/functional/ControlledBFTNetwork.java
+++ b/radixdlt/src/integration/java/com/radixdlt/consensus/functional/ControlledBFTNetwork.java
@@ -106,6 +106,7 @@ public final class ControlledBFTNetwork {
 			return msg;
 		}
 
+		@Override
 		public String toString() {
 			return channelId + " " + msg;
 		}

--- a/radixdlt/src/integration/java/com/radixdlt/consensus/functional/ControlledBFTNode.java
+++ b/radixdlt/src/integration/java/com/radixdlt/consensus/functional/ControlledBFTNode.java
@@ -111,8 +111,7 @@ class ControlledBFTNode {
 			pacemaker,
 			vertexStore,
 			proposerElection,
-			syncQueues,
-			systemCounters
+			syncQueues
 		);
 	}
 

--- a/radixdlt/src/main/java/com/radixdlt/consensus/BFTEventPreprocessor.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/BFTEventPreprocessor.java
@@ -20,7 +20,6 @@ package com.radixdlt.consensus;
 import com.radixdlt.consensus.SyncQueues.SyncQueue;
 import com.radixdlt.consensus.liveness.PacemakerState;
 import com.radixdlt.consensus.liveness.ProposerElection;
-import com.radixdlt.counters.SystemCounters;
 import com.radixdlt.crypto.ECPublicKey;
 import com.radixdlt.crypto.Hash;
 import java.util.Objects;
@@ -47,7 +46,6 @@ public final class BFTEventPreprocessor implements BFTEventProcessor {
 	private final VertexStore vertexStore;
 	private final PacemakerState pacemakerState;
 	private final ProposerElection proposerElection;
-	private final SystemCounters counters;
 	private final SyncQueues queues;
 
 	public BFTEventPreprocessor(
@@ -56,15 +54,13 @@ public final class BFTEventPreprocessor implements BFTEventProcessor {
 		PacemakerState pacemakerState,
 		VertexStore vertexStore,
 		ProposerElection proposerElection,
-		SyncQueues queues,
-		SystemCounters counters
+		SyncQueues queues
 	) {
 		this.myKey = Objects.requireNonNull(myKey);
 		this.pacemakerState = Objects.requireNonNull(pacemakerState);
 		this.vertexStore = Objects.requireNonNull(vertexStore);
 		this.proposerElection = Objects.requireNonNull(proposerElection);
 		this.queues = queues;
-		this.counters = Objects.requireNonNull(counters);
 		this.forwardTo = forwardTo;
 	}
 
@@ -99,6 +95,7 @@ public final class BFTEventPreprocessor implements BFTEventProcessor {
 	 *
 	 * @param vertexId the id of the vertex which is now guaranteed be synced.
 	 */
+	@Override
 	public void processLocalSync(Hash vertexId) {
 		for (SyncQueue queue : queues.getQueues()) {
 			if (peekAndExecute(queue, vertexId)) {

--- a/radixdlt/src/main/java/com/radixdlt/consensus/BFTEventReducer.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/BFTEventReducer.java
@@ -120,7 +120,6 @@ public final class BFTEventReducer implements BFTEventProcessor {
 			if (committedAtom != null) {
 				mempool.removeCommittedAtom(committedAtom.getAID());
 			}
-			this.pendingVotes.removeVotesUpto(qc.getView());
 		});
 
 		// proceed to next view if pacemaker feels like it

--- a/radixdlt/src/main/java/com/radixdlt/consensus/BFTEventReducer.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/BFTEventReducer.java
@@ -113,14 +113,15 @@ public final class BFTEventReducer implements BFTEventProcessor {
 
 	private void processQC(QuorumCertificate qc) {
 		// commit any newly committable vertices
-		this.safetyRules.process(qc).ifPresent(vertexId -> {
-			final Vertex vertex = vertexStore.commitVertex(vertexId);
-			log.info("{}: Committed vertex: {}", this.getShortName(), vertex);
-			final Atom committedAtom = vertex.getAtom();
-			if (committedAtom != null) {
-				mempool.removeCommittedAtom(committedAtom.getAID());
-			}
-		});
+		this.safetyRules.process(qc)
+			.ifPresent(vertexId -> {
+				final Vertex vertex = vertexStore.commitVertex(vertexId);
+				log.info("{}: Committed vertex: {}", this.getShortName(), vertex);
+				final Atom committedAtom = vertex.getAtom();
+				if (committedAtom != null) {
+					mempool.removeCommittedAtom(committedAtom.getAID());
+				}
+			});
 
 		// proceed to next view if pacemaker feels like it
 		this.pacemaker.processQC(qc.getView())

--- a/radixdlt/src/main/java/com/radixdlt/consensus/EpochManager.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/EpochManager.java
@@ -111,8 +111,7 @@ public class EpochManager {
 			this.pacemaker,
 			this.vertexStore,
 			proposerElection,
-			syncQueues,
-			counters
+			syncQueues
 		);
 	}
 }

--- a/radixdlt/src/main/java/com/radixdlt/consensus/validators/ValidationState.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/validators/ValidationState.java
@@ -80,7 +80,7 @@ public final class ValidationState {
 	public boolean addSignature(ECPublicKey key, ECDSASignature signature) {
 		if (validatorSet.containsKey(key)
 			&& !this.signedKeys.containsKey(key)) {
-			this.signedKeys.compute(key, (k, v) -> {
+			this.signedKeys.computeIfAbsent(key, k -> {
 				this.signedPower = this.signedPower.add(this.validatorSet.getPower(key));
 				return signature;
 			});

--- a/radixdlt/src/main/java/com/radixdlt/consensus/validators/ValidatorSet.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/validators/ValidatorSet.java
@@ -25,7 +25,6 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import com.radixdlt.crypto.ECPublicKey;
-import com.radixdlt.crypto.Hash;
 
 /**
  * Set of validators for consensus. Only validators with power >= 1 will
@@ -68,11 +67,10 @@ public final class ValidatorSet {
 	/**
 	 * Create an initial validation state with no signatures for this validator set.
 	 *
-	 * @param anchor The hash to validate signatures against
 	 * @return An initial validation state with no signatures
 	 */
-	public ValidationState newValidationState(Hash anchor) {
-		return ValidationState.forValidatorSet(anchor, this);
+	public ValidationState newValidationState() {
+		return ValidationState.forValidatorSet(this);
 	}
 
 	public boolean containsKey(ECPublicKey key) {

--- a/radixdlt/src/test/java/com/radixdlt/consensus/BFTEventPreprocessorTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/BFTEventPreprocessorTest.java
@@ -31,7 +31,6 @@ import com.google.common.collect.ImmutableSet;
 import com.radixdlt.consensus.SyncQueues.SyncQueue;
 import com.radixdlt.consensus.liveness.Pacemaker;
 import com.radixdlt.consensus.liveness.ProposerElection;
-import com.radixdlt.counters.SystemCounters;
 import com.radixdlt.crypto.ECKeyPair;
 import com.radixdlt.crypto.ECPublicKey;
 import com.radixdlt.crypto.Hash;
@@ -45,7 +44,6 @@ public class BFTEventPreprocessorTest {
 	private ProposerElection proposerElection;
 	private Pacemaker pacemaker;
 	private VertexStore vertexStore;
-	private SystemCounters counters;
 	private BFTEventProcessor forwardTo;
 	private SyncQueues syncQueues;
 
@@ -54,7 +52,6 @@ public class BFTEventPreprocessorTest {
 		this.pacemaker = mock(Pacemaker.class);
 		this.vertexStore = mock(VertexStore.class);
 		this.proposerElection = mock(ProposerElection.class);
-		this.counters = mock(SystemCounters.class);
 		this.forwardTo = mock(BFTEventProcessor.class);
 		this.syncQueues = mock(SyncQueues.class);
 
@@ -67,8 +64,7 @@ public class BFTEventPreprocessorTest {
 			pacemaker,
 			vertexStore,
 			proposerElection,
-			syncQueues,
-			counters
+			syncQueues
 		);
 	}
 

--- a/radixdlt/src/test/java/com/radixdlt/consensus/BFTEventReducerTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/BFTEventReducerTest.java
@@ -138,7 +138,7 @@ public class BFTEventReducerTest {
 		QuorumCertificate qc = mock(QuorumCertificate.class);
 		View view = mock(View.class);
 		when(qc.getView()).thenReturn(view);
-		when(pendingVotes.insertVote(eq(vote))).thenReturn(Optional.of(qc));
+		when(pendingVotes.insertVote(eq(vote), any())).thenReturn(Optional.of(qc));
 		when(mempool.getAtoms(anyInt(), any())).thenReturn(Lists.newArrayList());
 		when(pacemaker.getCurrentView()).thenReturn(mock(View.class));
 		when(pacemaker.processQC(eq(view))).thenReturn(Optional.of(mock(View.class)));

--- a/radixdlt/src/test/java/com/radixdlt/consensus/BFTEventReducerTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/BFTEventReducerTest.java
@@ -138,7 +138,7 @@ public class BFTEventReducerTest {
 		QuorumCertificate qc = mock(QuorumCertificate.class);
 		View view = mock(View.class);
 		when(qc.getView()).thenReturn(view);
-		when(pendingVotes.insertVote(eq(vote), any())).thenReturn(Optional.of(qc));
+		when(pendingVotes.insertVote(eq(vote))).thenReturn(Optional.of(qc));
 		when(mempool.getAtoms(anyInt(), any())).thenReturn(Lists.newArrayList());
 		when(pacemaker.getCurrentView()).thenReturn(mock(View.class));
 		when(pacemaker.processQC(eq(view))).thenReturn(Optional.of(mock(View.class)));

--- a/radixdlt/src/test/java/com/radixdlt/consensus/PendingVotesTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/PendingVotesTest.java
@@ -23,6 +23,7 @@ import com.radixdlt.consensus.validators.ValidatorSet;
 import com.radixdlt.crypto.ECDSASignature;
 import com.radixdlt.crypto.ECDSASignatures;
 import com.radixdlt.crypto.ECKeyPair;
+import com.radixdlt.crypto.ECPublicKey;
 import com.radixdlt.crypto.Hash;
 import com.radixdlt.utils.UInt256;
 import java.util.Collections;
@@ -35,8 +36,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class PendingVotesTest {
 	private PendingVotes pendingVotes;
@@ -50,11 +54,18 @@ public class PendingVotesTest {
 	}
 
 	@Test
+	public void equalsContractForPreviousVote() {
+		EqualsVerifier.forClass(PendingVotes.PreviousVote.class)
+			.verify();
+	}
+
+	@Test
 	public void when_inserting_a_vote_without_signature__then_exception_is_thrown() {
-		Vote voteWithoutSignature = makeUnsignedVoteFor(Hash.random());
+		Vote voteWithoutSignature = makeUnsignedVoteFor(ECKeyPair.generateNew().getPublicKey(), View.genesis(), Hash.random());
 
 		VoteData voteData = mock(VoteData.class);
 		ValidatorSet validatorSet = mock(ValidatorSet.class);
+		when(validatorSet.containsKey(any())).thenReturn(true);
 		VertexMetadata proposed = voteWithoutSignature.getVoteData().getProposed();
 		when(voteData.getProposed()).thenReturn(proposed);
 
@@ -65,8 +76,8 @@ public class PendingVotesTest {
 	@Test
 	public void when_inserting_valid_but_unaccepted_votes__then_no_qc_is_returned() {
 		Hash vertexId = Hash.random();
-		Vote vote1 = makeSignedVoteFor(vertexId);
-		Vote vote2 = makeSignedVoteFor(vertexId);
+		Vote vote1 = makeSignedVoteFor(ECKeyPair.generateNew().getPublicKey(), View.genesis(), vertexId);
+		Vote vote2 = makeSignedVoteFor(ECKeyPair.generateNew().getPublicKey(), View.genesis(), vertexId);
 
 		ValidatorSet validatorSet = ValidatorSet.from(Collections.singleton(Validator.from(vote1.getAuthor(), UInt256.ONE)));
 		VoteData voteData = mock(VoteData.class);
@@ -78,14 +89,18 @@ public class PendingVotesTest {
 
 	@Test
 	public void when_inserting_valid_and_accepted_votes__then_qc_is_formed() {
-		Vote vote = makeSignedVoteFor(Hash.random());
+		ECPublicKey author = mock(ECPublicKey.class);
+		when(author.verify(any(Hash.class), any())).thenReturn(true);
+		Vote vote = makeSignedVoteFor(author, View.genesis(), Hash.random());
 
 		ValidatorSet validatorSet = mock(ValidatorSet.class);
 		ValidationState validationState = mock(ValidationState.class);
 		ECDSASignatures signatures = mock(ECDSASignatures.class);
 		when(validationState.addSignature(any(), any())).thenReturn(true);
+		when(validationState.complete()).thenReturn(true);
 		when(validationState.signatures()).thenReturn(signatures);
-		when(validatorSet.newValidationState(any())).thenReturn(validationState);
+		when(validatorSet.newValidationState()).thenReturn(validationState);
+		when(validatorSet.containsKey(any())).thenReturn(true);
 
 		VoteData voteData = mock(VoteData.class);
 		VertexMetadata proposed = vote.getVoteData().getProposed();
@@ -95,15 +110,18 @@ public class PendingVotesTest {
 	}
 
 	@Test
-	public void when_removing_state__state_is_removed() {
-		Vote vote = makeSignedVoteFor(Hash.random());
+	public void when_voting_again__previous_vote_is_removed() {
+		ECPublicKey author = mock(ECPublicKey.class);
+		when(author.verify(any(Hash.class), any())).thenReturn(true);
+		Vote vote = makeSignedVoteFor(author, View.genesis(), Hash.random());
 
 		ValidatorSet validatorSet = mock(ValidatorSet.class);
 		ValidationState validationState = mock(ValidationState.class);
 		ECDSASignatures signatures = mock(ECDSASignatures.class);
-		when(validationState.addSignature(any(), any())).thenReturn(false);
 		when(validationState.signatures()).thenReturn(signatures);
-		when(validatorSet.newValidationState(any())).thenReturn(validationState);
+		when(validationState.isEmpty()).thenReturn(true);
+		when(validatorSet.newValidationState()).thenReturn(validationState);
+		when(validatorSet.containsKey(any())).thenReturn(true);
 
 		VoteData voteData = mock(VoteData.class);
 		VertexMetadata proposed = vote.getVoteData().getProposed();
@@ -111,36 +129,36 @@ public class PendingVotesTest {
 
 		// Preconditions
 		assertThat(this.pendingVotes.insertVote(vote, validatorSet)).isNotPresent();
-		assertEquals(1, this.pendingVotes.stateSize());
+		assertEquals(1, this.pendingVotes.voteStateSize());
+		assertEquals(1, this.pendingVotes.previousVotesSize());
 
-		// Removing prior to inserted vote should remove nothing
-		this.pendingVotes.removeVotesUpto(View.genesis());
-		assertEquals(1, this.pendingVotes.stateSize());
-
-		// Removing inserted vote should empty state
-		this.pendingVotes.removeVotesUpto(View.of(1));
-		assertEquals(0, this.pendingVotes.stateSize());
+		Vote vote2 = makeSignedVoteFor(author, View.of(1), Hash.random());
+		// Need a different hash for this (different) vote
+		when(hasher.hash(eq(vote2.getVoteData()))).thenReturn(Hash.random());
+		assertThat(this.pendingVotes.insertVote(vote2, validatorSet)).isNotPresent();
+		assertEquals(1, this.pendingVotes.voteStateSize());
+		assertEquals(1, this.pendingVotes.previousVotesSize());
 	}
 
-	private Vote makeUnsignedVoteFor(Hash vertexId) {
-		Vote vote = makeVoteWithoutSignatureFor(vertexId);
+	private Vote makeUnsignedVoteFor(ECPublicKey author, View parentView, Hash vertexId) {
+		Vote vote = makeVoteWithoutSignatureFor(author, parentView, vertexId);
 		when(vote.getSignature()).thenReturn(Optional.empty());
 		return vote;
 	}
 
-	private Vote makeSignedVoteFor(Hash vertexId) {
-		Vote vote = makeVoteWithoutSignatureFor(vertexId);
+	private Vote makeSignedVoteFor(ECPublicKey author, View parentView, Hash vertexId) {
+		Vote vote = makeVoteWithoutSignatureFor(author, parentView, vertexId);
 		when(vote.getSignature()).thenReturn(Optional.of(new ECDSASignature()));
 		return vote;
 	}
 
-	private Vote makeVoteWithoutSignatureFor(Hash vertexId) {
+	private Vote makeVoteWithoutSignatureFor(ECPublicKey author, View parentView, Hash vertexId) {
 		Vote vote = mock(Vote.class);
-		VertexMetadata proposed = new VertexMetadata(View.of(1), vertexId, 1);
-		VertexMetadata parent = new VertexMetadata(View.of(0), Hash.random(), 0);
+		VertexMetadata proposed = new VertexMetadata(parentView.next(), vertexId, 1);
+		VertexMetadata parent = new VertexMetadata(parentView, Hash.random(), 0);
 		VoteData voteData = new VoteData(proposed, parent);
 		when(vote.getVoteData()).thenReturn(voteData);
-		when(vote.getAuthor()).thenReturn(ECKeyPair.generateNew().getPublicKey());
+		when(vote.getAuthor()).thenReturn(author);
 		return vote;
 	}
 }

--- a/radixdlt/src/test/java/com/radixdlt/consensus/liveness/FixedTimeoutPacemakerTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/liveness/FixedTimeoutPacemakerTest.java
@@ -26,6 +26,8 @@ import com.radixdlt.consensus.validators.ValidatorSet;
 import com.radixdlt.crypto.ECDSASignature;
 import com.radixdlt.crypto.ECKeyPair;
 import com.radixdlt.crypto.ECPublicKey;
+import com.radixdlt.crypto.Hash;
+
 import org.junit.Before;
 import com.radixdlt.utils.UInt256;
 import org.junit.Test;
@@ -143,7 +145,8 @@ public class FixedTimeoutPacemakerTest {
 		ValidatorSet validatorSet = mock(ValidatorSet.class);
 		ValidationState validationState = mock(ValidationState.class);
 		when(validationState.addSignature(any(), any())).thenReturn(true);
-		when(validatorSet.newValidationState(any())).thenReturn(validationState);
+		when(validationState.complete()).thenReturn(true);
+		when(validatorSet.newValidationState()).thenReturn(validationState);
 		pacemaker.processQC(View.of(0));
 
 		assertThat(pacemaker.processNewView(newView, validatorSet)).isPresent().get().isEqualTo(View.of(1));
@@ -183,7 +186,7 @@ public class FixedTimeoutPacemakerTest {
 		ValidatorSet validatorSet = mock(ValidatorSet.class);
 		ValidationState validationState = mock(ValidationState.class);
 		when(validationState.complete()).thenReturn(true);
-		when(validatorSet.newValidationState(any())).thenReturn(validationState);
+		when(validatorSet.newValidationState()).thenReturn(validationState);
 
 		pacemaker.processQC(View.genesis());
 		verify(timeoutSender, times(1)).scheduleTimeout(any(), anyLong());
@@ -201,7 +204,9 @@ public class FixedTimeoutPacemakerTest {
 		when(newView.getQC()).thenReturn(qc);
 		when(newView.getView()).thenReturn(view);
 		when(newView.getSignature()).thenReturn(Optional.of(new ECDSASignature()));
-		when(newView.getAuthor()).thenReturn(ECKeyPair.generateNew().getPublicKey());
+		ECPublicKey author = mock(ECPublicKey.class);
+		when(author.verify(any(Hash.class), any())).thenReturn(true);
+		when(newView.getAuthor()).thenReturn(author);
 		return newView;
 	}
 }

--- a/radixdlt/src/test/java/com/radixdlt/consensus/liveness/WeightedRotatingLeadersTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/liveness/WeightedRotatingLeadersTest.java
@@ -123,6 +123,8 @@ public class WeightedRotatingLeadersTest {
 			.collect(ImmutableList.toImmutableList());
 
 		ValidatorSet validatorSet = ValidatorSet.from(validatorsInOrder);
+		// SuppressWarnings is fine here for mocked Comparator
+		@SuppressWarnings("unchecked")
 		Comparator<Validator> validatorComparator = mock(Comparator.class);
 		this.weightedRotatingLeaders = new WeightedRotatingLeaders(validatorSet, validatorComparator, sizeOfCache);
 

--- a/radixdlt/src/test/java/com/radixdlt/consensus/validators/ValidatorSetTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/validators/ValidatorSetTest.java
@@ -63,33 +63,41 @@ public class ValidatorSetTest {
 		Hash message = Hash.random();
 
 		// 2 signatures for 4 validators -> fail
-		ValidationState vst1 = vs.newValidationState(message);
-		assertFalse(vst1.addSignature(k1.getPublicKey(), k1.sign(message)));
-		assertFalse(vst1.addSignature(k2.getPublicKey(), k2.sign(message)));
+		ValidationState vst1 = vs.newValidationState();
+		assertTrue(vst1.addSignature(k1.getPublicKey(), k1.sign(message)));
+		assertFalse(vst1.complete());
+		assertTrue(vst1.addSignature(k2.getPublicKey(), k2.sign(message)));
 		assertFalse(vst1.complete());
 		assertEquals(2, vst1.signatures().count());
 
 		// 3 signatures for 4 validators -> pass
-		ValidationState vst2 = vs.newValidationState(message);
-		assertFalse(vst2.addSignature(k1.getPublicKey(), k1.sign(message)));
-		assertFalse(vst2.addSignature(k2.getPublicKey(), k2.sign(message)));
+		ValidationState vst2 = vs.newValidationState();
+		assertTrue(vst2.addSignature(k1.getPublicKey(), k1.sign(message)));
+		assertFalse(vst1.complete());
+		assertTrue(vst2.addSignature(k2.getPublicKey(), k2.sign(message)));
+		assertFalse(vst1.complete());
 		assertTrue(vst2.addSignature(k3.getPublicKey(), k3.sign(message)));
 		assertTrue(vst2.complete());
 		assertEquals(3, vst2.signatures().count());
 
 		// 2 signatures + 1 signature not from set for 4 validators -> fail
-		ValidationState vst3 = vs.newValidationState(message);
-		assertFalse(vst3.addSignature(k1.getPublicKey(), k1.sign(message)));
-		assertFalse(vst3.addSignature(k2.getPublicKey(), k2.sign(message)));
+		ValidationState vst3 = vs.newValidationState();
+		assertTrue(vst3.addSignature(k1.getPublicKey(), k1.sign(message)));
+		assertFalse(vst3.complete());
+		assertTrue(vst3.addSignature(k2.getPublicKey(), k2.sign(message)));
+		assertFalse(vst3.complete());
 		assertFalse(vst3.addSignature(k5.getPublicKey(), k5.sign(message)));
 		assertFalse(vst3.complete());
 		assertEquals(2, vst3.signatures().count());
 
 		// 3 signatures + 1 signature not from set for 4 validators -> pass
-		ValidationState vst4 = vs.newValidationState(message);
-		assertFalse(vst4.addSignature(k1.getPublicKey(), k1.sign(message)));
-		assertFalse(vst4.addSignature(k2.getPublicKey(), k2.sign(message)));
+		ValidationState vst4 = vs.newValidationState();
+		assertTrue(vst4.addSignature(k1.getPublicKey(), k1.sign(message)));
+		assertFalse(vst3.complete());
+		assertTrue(vst4.addSignature(k2.getPublicKey(), k2.sign(message)));
+		assertFalse(vst3.complete());
 		assertFalse(vst4.addSignature(k5.getPublicKey(), k5.sign(message)));
+		assertFalse(vst3.complete());
 		assertTrue(vst4.addSignature(k3.getPublicKey(), k3.sign(message)));
 		assertTrue(vst4.complete());
 		assertEquals(3, vst4.signatures().count());
@@ -105,7 +113,7 @@ public class ValidatorSetTest {
 
 		ValidatorSet vs = ValidatorSet.from(ImmutableSet.of(v1, v2));
 		Hash message = Hash.random();
-		ValidationState vst1 = vs.newValidationState(message);
+		ValidationState vst1 = vs.newValidationState();
 		assertTrue(vst1.addSignature(k1.getPublicKey(), k1.sign(message)));
 		assertTrue(vst1.complete());
 		assertEquals(1, vst1.signatures().count());


### PR DESCRIPTION
Make voting rounds have a more clearly defined lifecycle

Either:
- Proposal/start voting -> QC formed/voting closed
or
- Proposal/start voting -> Timeout/voting closed
