### PR TITLE
Add stateVersion per vertex

### DIFF
--- a/radixdlt/src/main/java/com/radixdlt/CerberusModule.java
+++ b/radixdlt/src/main/java/com/radixdlt/CerberusModule.java
@@ -139,7 +139,7 @@ public class CerberusModule extends AbstractModule {
 		}
 
 		final Vertex genesisVertex = Vertex.createGenesis(universe.getGenesis().get(0));
-		final VertexMetadata genesisMetadata = new VertexMetadata(View.genesis(), genesisVertex.getId());
+		final VertexMetadata genesisMetadata = new VertexMetadata(View.genesis(), genesisVertex.getId(), 0);
 		final VoteData voteData = new VoteData(genesisMetadata, null);
 		final QuorumCertificate rootQC = new QuorumCertificate(voteData, new ECDSASignatures());
 

--- a/radixdlt/src/main/java/com/radixdlt/consensus/VertexMetadata.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/VertexMetadata.java
@@ -59,7 +59,7 @@ public final class VertexMetadata {
 		}
 
 		this.stateVersion = stateVersion;
-        this.view = view;
+		this.view = view;
 		this.id = id;
 	}
 
@@ -72,7 +72,8 @@ public final class VertexMetadata {
 			parentStateVersion = parent.getStateVersion();
 		}
 
-		final long newStateVersion = parentStateVersion + (vertex.getAtom() != null ? 1 : 0);
+		final int versionIncrement = vertex.getAtom() != null ? 1 : 0;
+		final long newStateVersion = parentStateVersion + versionIncrement;
 		return new VertexMetadata(vertex.getView(), vertex.getId(), newStateVersion);
 	}
 

--- a/radixdlt/src/main/java/com/radixdlt/consensus/VertexMetadata.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/VertexMetadata.java
@@ -42,27 +42,42 @@ public final class VertexMetadata {
 	@DsonOutput(Output.ALL)
 	private final Hash id;
 
+	@JsonProperty("stateVersion")
+	@DsonOutput(Output.ALL)
+	private final long stateVersion;
+
 	VertexMetadata() {
 		// Serializer only
 		this.view = null;
 		this.id = null;
+		this.stateVersion = 0L;
 	}
 
-	public VertexMetadata(View view, Hash id) {
+	public VertexMetadata(View view, Hash id, long stateVersion) {
+		if (stateVersion < 0) {
+			throw new IllegalArgumentException("stateVersion must be >= 0");
+		}
+
+		this.stateVersion = stateVersion;
         this.view = view;
 		this.id = id;
 	}
 
 	public static VertexMetadata ofVertex(Vertex vertex) {
-		return new VertexMetadata(vertex.getView(), vertex.getId());
-	}
-
-	public static VertexMetadata ofParent(Vertex vertex) {
+		final long parentStateVersion;
 		if (vertex.isGenesis()) {
-			throw new IllegalStateException("Genesis has no parent.");
+			parentStateVersion = 0;
+		} else {
+			final VertexMetadata parent = vertex.getQC().getProposed();
+			parentStateVersion = parent.getStateVersion();
 		}
 
-		return new VertexMetadata(vertex.getParentView(), vertex.getParentId());
+		final long newStateVersion = parentStateVersion + (vertex.getAtom() != null ? 1 : 0);
+		return new VertexMetadata(vertex.getView(), vertex.getId(), newStateVersion);
+	}
+
+	public long getStateVersion() {
+		return stateVersion;
 	}
 
 	public View getView() {
@@ -86,7 +101,7 @@ public final class VertexMetadata {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(this.view, this.id);
+		return Objects.hash(this.view, this.id, this.stateVersion);
 	}
 
 	@Override
@@ -98,7 +113,8 @@ public final class VertexMetadata {
 			VertexMetadata other = (VertexMetadata) o;
 			return
 				Objects.equals(this.view, other.view)
-				&& Objects.equals(this.id, other.id);
+				&& Objects.equals(this.id, other.id)
+				&& this.stateVersion == other.stateVersion;
 		}
 		return false;
 	}

--- a/radixdlt/src/test/java/com/radixdlt/consensus/BFTEventReducerTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/BFTEventReducerTest.java
@@ -115,8 +115,8 @@ public class BFTEventReducerTest {
 	@Test
 	public void when_processing_vote_as_not_proposer__then_nothing_happens() {
 		Vote voteMessage = mock(Vote.class);
-		VertexMetadata proposal = new VertexMetadata(View.of(2), Hash.random());
-		VertexMetadata parent = new VertexMetadata(View.of(1), Hash.random());
+		VertexMetadata proposal = new VertexMetadata(View.of(2), Hash.random(), 2);
+		VertexMetadata parent = new VertexMetadata(View.of(1), Hash.random(), 1);
 		VoteData voteData = new VoteData(proposal, parent);
 		when(voteMessage.getVoteData()).thenReturn(voteData);
 
@@ -130,8 +130,8 @@ public class BFTEventReducerTest {
 		when(proposerElection.getProposer(any())).thenReturn(SELF_KEY.getPublicKey());
 
 		Vote vote = mock(Vote.class);
-		VertexMetadata proposal = new VertexMetadata(View.of(2), Hash.random());
-		VertexMetadata parent = new VertexMetadata(View.of(1), Hash.random());
+		VertexMetadata proposal = new VertexMetadata(View.of(2), Hash.random(), 2);
+		VertexMetadata parent = new VertexMetadata(View.of(1), Hash.random(), 1);
 		VoteData voteData = new VoteData(proposal, parent);
 		when(vote.getVoteData()).thenReturn(voteData);
 

--- a/radixdlt/src/test/java/com/radixdlt/consensus/PendingVotesTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/PendingVotesTest.java
@@ -80,8 +80,8 @@ public class PendingVotesTest {
 
 	private Vote makeVoteFor(Hash vertexId) {
 		Vote vote = mock(Vote.class);
-		VertexMetadata proposed = new VertexMetadata(View.of(1), vertexId);
-		VertexMetadata parent = new VertexMetadata(View.of(0), Hash.random());
+		VertexMetadata proposed = new VertexMetadata(View.of(1), vertexId, 1);
+		VertexMetadata parent = new VertexMetadata(View.of(0), Hash.random(), 0);
 		VoteData voteData = new VoteData(proposed, parent);
 		when(vote.getVoteData()).thenReturn(voteData);
 		when(vote.getSignature()).thenReturn(Optional.of(new ECDSASignature()));

--- a/radixdlt/src/test/java/com/radixdlt/consensus/VertexMetadataTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/VertexMetadataTest.java
@@ -34,7 +34,7 @@ public class VertexMetadataTest {
 		View view = View.of(1234567890L);
 		this.id = Hash.random();
 
-		this.testObject = new VertexMetadata(view, id);
+		this.testObject = new VertexMetadata(view, id, 0);
 	}
 
 	@Test

--- a/radixdlt/src/test/java/com/radixdlt/consensus/VertexStoreTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/VertexStoreTest.java
@@ -46,7 +46,7 @@ public class VertexStoreTest {
 	@Before
 	public void setUp() {
 		this.genesisVertex = Vertex.createGenesis(null);
-		this.genesisVertexMetadata = new VertexMetadata(View.genesis(), genesisVertex.getId());
+		this.genesisVertexMetadata = new VertexMetadata(View.genesis(), genesisVertex.getId(), 0);
 		VoteData voteData = new VoteData(genesisVertexMetadata, null);
 		this.rootQC = new QuorumCertificate(voteData, new ECDSASignatures());
 		this.radixEngine = mock(RadixEngine.class);
@@ -88,7 +88,7 @@ public class VertexStoreTest {
 
 	@Test
 	public void when_inserting_vertex_with_missing_parent__then_missing_parent_exception_is_thrown() {
-		VertexMetadata vertexMetadata = new VertexMetadata(View.genesis(), Hash.ZERO_HASH);
+		VertexMetadata vertexMetadata = new VertexMetadata(View.genesis(), Hash.ZERO_HASH, 0);
 		VoteData voteData = new VoteData(vertexMetadata, null);
 		QuorumCertificate qc = new QuorumCertificate(voteData, new ECDSASignatures());
 		Vertex nextVertex = Vertex.createVertex(qc, View.of(1), mock(Atom.class));
@@ -115,7 +115,7 @@ public class VertexStoreTest {
 	@Test
 	public void when_insert_two_vertices__then_get_path_from_root_should_return_the_two_vertices() throws Exception {
 		Vertex nextVertex0 = Vertex.createVertex(rootQC, View.of(1), null);
-		VertexMetadata vertexMetadata = new VertexMetadata(View.of(1), nextVertex0.getId());
+		VertexMetadata vertexMetadata = new VertexMetadata(View.of(1), nextVertex0.getId(), 1);
 		VoteData voteData = new VoteData(vertexMetadata, rootQC.getProposed());
 		QuorumCertificate qc = new QuorumCertificate(voteData, new ECDSASignatures());
 		Vertex nextVertex1 = Vertex.createVertex(qc, View.of(2), null);

--- a/radixdlt/src/test/java/com/radixdlt/consensus/VertexTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/VertexTest.java
@@ -40,8 +40,8 @@ public class VertexTest {
 		View baseView = View.of(1234567890L);
 		Hash id = Hash.random();
 
-		VertexMetadata vertexMetadata = new VertexMetadata(baseView.next(), id);
-		VertexMetadata parent = new VertexMetadata(baseView, Hash.random());
+		VertexMetadata vertexMetadata = new VertexMetadata(baseView.next(), id, 1);
+		VertexMetadata parent = new VertexMetadata(baseView, Hash.random(), 0);
 		VoteData voteData = new VoteData(vertexMetadata, parent);
 
 		this.qc = new QuorumCertificate(voteData, new ECDSASignatures());
@@ -67,8 +67,8 @@ public class VertexTest {
 		View baseView = View.of(1234567890L);
 		Hash id = Hash.random();
 
-		VertexMetadata vertexMetadata = new VertexMetadata(baseView.next(), id);
-		VertexMetadata parent = new VertexMetadata(baseView, Hash.random());
+		VertexMetadata vertexMetadata = new VertexMetadata(baseView.next(), id, 1);
+		VertexMetadata parent = new VertexMetadata(baseView, Hash.random(), 0);
 		VoteData voteData = new VoteData(vertexMetadata, parent);
 		QuorumCertificate qc2 = new QuorumCertificate(voteData, new ECDSASignatures());
 		Atom atom2 = new Atom();

--- a/radixdlt/src/test/java/com/radixdlt/consensus/VoteTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/VoteTest.java
@@ -37,8 +37,8 @@ public class VoteTest {
 		View view = View.of(1234567891L);
 		Hash id = Hash.random();
 
-		VertexMetadata parent = new VertexMetadata(View.of(1234567890L), Hash.random());
-		this.voteData = new VoteData(new VertexMetadata(view, id), parent);
+		VertexMetadata parent = new VertexMetadata(View.of(1234567890L), Hash.random(), 1);
+		this.voteData = new VoteData(new VertexMetadata(view, id, 0), parent);
 
 		this.testObject = new Vote(ADDRESS.getPublicKey(), voteData, null);
 	}

--- a/radixdlt/src/test/java/com/radixdlt/consensus/safety/SafetyRulesTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/safety/SafetyRulesTest.java
@@ -86,7 +86,7 @@ public class SafetyRulesTest {
 		Vertex vertex = Vertex.createVertex(GENESIS_QC, View.of(1), null);
 		Vote vote = safetyRules.voteFor(vertex);
 		assertThat(vote.getVoteData().getProposed()).isEqualTo(VertexMetadata.ofVertex(vertex));
-		assertThat(vote.getVoteData().getParent()).isEqualTo(VertexMetadata.ofParent(vertex));
+		assertThat(vote.getVoteData().getParent()).isEqualTo(vertex.getQC().getProposed());
 		assertThat(vote.getVoteData().getCommitted()).isEmpty();
 	}
 
@@ -96,7 +96,7 @@ public class SafetyRulesTest {
 		when(safetyState.getLockedView()).thenReturn(View.of(0));
 		when(safetyState.toBuilder()).thenReturn(mock(Builder.class));
 		Vertex vertex = Vertex.createVertex(GENESIS_QC, View.of(1), null);
-		VoteData voteData = new VoteData(VertexMetadata.ofVertex(vertex), VertexMetadata.ofParent(vertex));
+		VoteData voteData = new VoteData(VertexMetadata.ofVertex(vertex), vertex.getQC().getProposed());
 		QuorumCertificate qc = new QuorumCertificate(voteData, new ECDSASignatures());
 		Vertex proposal = Vertex.createVertex(qc, View.of(2), null);
 		Vote vote = safetyRules.voteFor(proposal);
@@ -110,11 +110,11 @@ public class SafetyRulesTest {
 		when(safetyState.toBuilder()).thenReturn(mock(Builder.class));
 
 		Vertex grandParent = Vertex.createVertex(GENESIS_QC, View.of(1), null);
-		VoteData voteData = new VoteData(VertexMetadata.ofVertex(grandParent), VertexMetadata.ofParent(grandParent));
+		VoteData voteData = new VoteData(VertexMetadata.ofVertex(grandParent), grandParent.getQC().getProposed());
 		QuorumCertificate qc = new QuorumCertificate(voteData, new ECDSASignatures());
 
 		Vertex parent = Vertex.createVertex(qc, View.of(2), null);
-		VoteData parentVoteData = new VoteData(VertexMetadata.ofVertex(parent), VertexMetadata.ofParent(parent));
+		VoteData parentVoteData = new VoteData(VertexMetadata.ofVertex(parent), parent.getQC().getProposed());
 		QuorumCertificate parentQC = new QuorumCertificate(parentVoteData, new ECDSASignatures());
 
 		Vertex proposal = Vertex.createVertex(parentQC, View.of(3), null);
@@ -130,11 +130,11 @@ public class SafetyRulesTest {
 		when(safetyState.toBuilder()).thenReturn(mock(Builder.class));
 
 		Vertex grandParent = Vertex.createVertex(GENESIS_QC, View.of(1), null);
-		VoteData voteData = new VoteData(VertexMetadata.ofVertex(grandParent), VertexMetadata.ofParent(grandParent));
+		VoteData voteData = new VoteData(VertexMetadata.ofVertex(grandParent), grandParent.getQC().getProposed());
 		QuorumCertificate qc = new QuorumCertificate(voteData, new ECDSASignatures());
 
 		Vertex parent = Vertex.createVertex(qc, View.of(2), null);
-		VoteData parentVoteData = new VoteData(VertexMetadata.ofVertex(parent), VertexMetadata.ofParent(parent));
+		VoteData parentVoteData = new VoteData(VertexMetadata.ofVertex(parent), parent.getQC().getProposed());
 		QuorumCertificate parentQC = new QuorumCertificate(parentVoteData, new ECDSASignatures());
 
 		Vertex proposal = Vertex.createVertex(parentQC, View.of(4), null);
@@ -153,9 +153,9 @@ public class SafetyRulesTest {
 		Hash toBeCommitted = mock(Hash.class);
 
 		VoteData voteData = new VoteData(
-			new VertexMetadata(View.of(3), mock(Hash.class)),
-			new VertexMetadata(View.of(2), mock(Hash.class)),
-			new VertexMetadata(View.of(1), toBeCommitted)
+			new VertexMetadata(View.of(3), mock(Hash.class), 3),
+			new VertexMetadata(View.of(2), mock(Hash.class), 2),
+			new VertexMetadata(View.of(1), toBeCommitted, 1)
 		);
 
 		QuorumCertificate qc = new QuorumCertificate(voteData, new ECDSASignatures());

--- a/radixdlt/src/test/java/com/radixdlt/middleware2/network/ConsensusEventMessageSerializeTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/middleware2/network/ConsensusEventMessageSerializeTest.java
@@ -35,8 +35,8 @@ public class ConsensusEventMessageSerializeTest extends SerializeMessageObject<C
 
 	private static ConsensusEventMessage get() {
 		RadixAddress author = RadixAddress.from("JH1P8f3znbyrDj8F4RWpix7hRkgxqHjdW2fNnKpR3v6ufXnknor");
-		VertexMetadata vertexMetadata = new VertexMetadata(View.of(1), Hash.ZERO_HASH);
-		VertexMetadata parent = new VertexMetadata(View.of(0), Hash.ZERO_HASH);
+		VertexMetadata vertexMetadata = new VertexMetadata(View.of(1), Hash.ZERO_HASH, 1);
+		VertexMetadata parent = new VertexMetadata(View.of(0), Hash.ZERO_HASH, 0);
 		VoteData voteData = new VoteData(vertexMetadata, parent);
 		QuorumCertificate quorumCertificate = new QuorumCertificate(voteData, new ECDSASignatures());
 		NewView testView = new NewView(author.getPublicKey(), View.of(1234567890L), quorumCertificate, null);

--- a/radixdlt/src/test/java/org/radix/serialization/ProposalSerializeTest.java
+++ b/radixdlt/src/test/java/org/radix/serialization/ProposalSerializeTest.java
@@ -41,8 +41,8 @@ public class ProposalSerializeTest extends SerializeObject<Proposal> {
 		View view = View.of(1234567891L);
 		Hash id = Hash.random();
 
-		VertexMetadata vertexMetadata = new VertexMetadata(view, id);
-		VertexMetadata parent = new VertexMetadata(View.of(1234567890L), Hash.random());
+		VertexMetadata vertexMetadata = new VertexMetadata(view, id, 1);
+		VertexMetadata parent = new VertexMetadata(View.of(1234567890L), Hash.random(), 0);
 		VoteData voteData = new VoteData(vertexMetadata, parent);
 
 		QuorumCertificate qc = new QuorumCertificate(voteData, new ECDSASignatures());

--- a/radixdlt/src/test/java/org/radix/serialization/VertexMetadataSerializeTest.java
+++ b/radixdlt/src/test/java/org/radix/serialization/VertexMetadataSerializeTest.java
@@ -30,6 +30,6 @@ public class VertexMetadataSerializeTest extends SerializeObject<VertexMetadata>
 		View view = View.of(1234567890L);
 		Hash id = Hash.random();
 
-		return new VertexMetadata(view, id);
+		return new VertexMetadata(view, id, 0);
 	}
 }

--- a/radixdlt/src/test/java/org/radix/serialization/VertexSerializeTest.java
+++ b/radixdlt/src/test/java/org/radix/serialization/VertexSerializeTest.java
@@ -38,8 +38,8 @@ public class VertexSerializeTest extends SerializeObject<Vertex> {
 		View view = View.of(1234567891L);
 		Hash id = Hash.random();
 
-		VertexMetadata vertexMetadata = new VertexMetadata(view, id);
-		VertexMetadata parent = new VertexMetadata(View.of(1234567890L), Hash.random());
+		VertexMetadata vertexMetadata = new VertexMetadata(view, id, 1);
+		VertexMetadata parent = new VertexMetadata(View.of(1234567890L), Hash.random(), 0);
 		VoteData voteData = new VoteData(vertexMetadata, parent);
 
 		QuorumCertificate qc = new QuorumCertificate(voteData, new ECDSASignatures());

--- a/radixdlt/src/test/java/org/radix/serialization/VoteSerializeTest.java
+++ b/radixdlt/src/test/java/org/radix/serialization/VoteSerializeTest.java
@@ -33,8 +33,8 @@ public class VoteSerializeTest extends SerializeObject<Vote> {
 		View view = View.of(1234567891L);
 		Hash id = Hash.random();
 
-		VertexMetadata vertexMetadata = new VertexMetadata(view, id);
-		VertexMetadata parent = new VertexMetadata(View.of(1234567890L), Hash.random());
+		VertexMetadata vertexMetadata = new VertexMetadata(view, id, 1);
+		VertexMetadata parent = new VertexMetadata(View.of(1234567890L), Hash.random(), 0);
 		VoteData voteData = new VoteData(vertexMetadata, parent);
 		RadixAddress author = RadixAddress.from("JH1P8f3znbyrDj8F4RWpix7hRkgxqHjdW2fNnKpR3v6ufXnknor");
 		return new Vote(author.getPublicKey(), voteData, null);


### PR DESCRIPTION
To enable easy syncing logic:
Given some committed VertexMetaData, the number of atoms I must download is the difference in stateVersions