### PR TITLE
Feature/api return committed only

### DIFF
--- a/radixdlt/src/integration/java/com/radixdlt/consensus/simulation/asynchronous/CrashFaultNetworkTest.java
+++ b/radixdlt/src/integration/java/com/radixdlt/consensus/simulation/asynchronous/CrashFaultNetworkTest.java
@@ -240,7 +240,7 @@ public class CrashFaultNetworkTest {
 			+ numNodes * (maxLatency * 4 + bftNetwork.getPacemakerTimeout()); // four rounds plus timeout in bad case
 		// account for any inaccuracies, execution time, scheduling inefficiencies..
 		// the tolerance is high since we're only interested in qualitative progress in this test
-		double tolerance = 2.0;
+		double tolerance = 3.0;
 		int minimumLatencyPerRound = (int) (worstCaseLatencyPerRound * tolerance);
 		AtomicReference<View> highestQCView = new AtomicReference<>(View.genesis());
 		Observable<Object> progressCheck = Observable.interval(minimumLatencyPerRound, minimumLatencyPerRound, TimeUnit.MILLISECONDS)

--- a/radixdlt/src/main/java/com/radixdlt/consensus/VertexStore.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/VertexStore.java
@@ -92,6 +92,11 @@ public final class VertexStore {
 			throw new MissingParentException(vertex.getParentId());
 		}
 
+		// TODO: Don't check for state computer errors for now so that we don't
+		// TODO: have to deal with failing leader proposals
+		// TODO: Reinstate this when ProposalGenerator + Mempool can guarantee correct proposals
+		// TODO: (also see commitVertex->storeAtom)
+
 		vertices.put(vertex.getId(), vertex);
 		updateVertexStoreSize();
 	}
@@ -129,11 +134,9 @@ public final class VertexStore {
 			this.engine.store(vertexWithAtom.getAtom());
 			this.counters.increment(CounterType.LEDGER_STORED);
 		} catch (RadixEngineException e) {
-			// TODO: revisit TODO below since this moved from insertVertex to commitVertex
 			// TODO: Don't check for state computer errors for now so that we don't
 			// TODO: have to deal with failing leader proposals
 			// TODO: Reinstate this when ProposalGenerator + Mempool can guarantee correct proposals
-			//throw new VertexInsertionException("Failed to execute", e);
 		}
 	}
 

--- a/radixdlt/src/main/java/com/radixdlt/consensus/VertexStore.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/VertexStore.java
@@ -110,17 +110,7 @@ public final class VertexStore {
 
 		for (Vertex committed : path) {
 			if (committed.getAtom() != null) {
-				try {
-					this.counters.increment(CounterType.LEDGER_PROCESSED);
-					this.engine.store(committed.getAtom());
-					this.counters.increment(CounterType.LEDGER_STORED);
-				} catch (RadixEngineException e) {
-					// TODO: revisit TODO below since this moved from insertVertex to commitVertex
-					// TODO: Don't check for state computer errors for now so that we don't
-					// TODO: have to deal with failing leader proposals
-					// TODO: Reinstate this when ProposalGenerator + Mempool can guarantee correct proposals
-					//throw new VertexInsertionException("Failed to execute", e);
-				}
+				storeAtom(committed);
 			}
 
 			lastCommittedVertex.onNext(committed);
@@ -131,6 +121,20 @@ public final class VertexStore {
 
 		updateVertexStoreSize();
 		return tipVertex;
+	}
+
+	private void storeAtom(Vertex vertexWithAtom) {
+		try {
+			this.counters.increment(CounterType.LEDGER_PROCESSED);
+			this.engine.store(vertexWithAtom.getAtom());
+			this.counters.increment(CounterType.LEDGER_STORED);
+		} catch (RadixEngineException e) {
+			// TODO: revisit TODO below since this moved from insertVertex to commitVertex
+			// TODO: Don't check for state computer errors for now so that we don't
+			// TODO: have to deal with failing leader proposals
+			// TODO: Reinstate this when ProposalGenerator + Mempool can guarantee correct proposals
+			//throw new VertexInsertionException("Failed to execute", e);
+		}
 	}
 
 	public Observable<Vertex> lastCommittedVertex() {

--- a/radixdlt/src/test/java/com/radixdlt/consensus/VertexStoreTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/VertexStoreTest.java
@@ -100,7 +100,8 @@ public class VertexStoreTest {
 
 	@Test
 	@Ignore("Reinstate once better ProposalGenerator + Mempool is implemented")
-	public void when_inserting_vertex_which_fails_to_pass_re__then_vertex_insertion_exception_is_thrown() throws Exception {
+	public void when_inserting_vertex_which_fails_to_pass_re__then_vertex_insertion_exception_is_thrown()
+		throws Exception {
 		doThrow(mock(RadixEngineException.class)).when(radixEngine).store(any());
 
 		Vertex nextVertex = Vertex.createVertex(rootQC, View.of(1), mock(Atom.class));
@@ -115,7 +116,8 @@ public class VertexStoreTest {
 	}
 
 	@Test
-	public void when_insert_vertex__then_it_should_not_be_committed_or_stored_in_engine() throws VertexInsertionException, RadixEngineException {
+	public void when_insert_vertex__then_it_should_not_be_committed_or_stored_in_engine()
+		throws VertexInsertionException, RadixEngineException {
 		Vertex nextVertex = Vertex.createVertex(rootQC, View.of(1), null);
 		vertexStore.insertVertex(nextVertex);
 
@@ -127,7 +129,8 @@ public class VertexStoreTest {
 	}
 
 	@Test
-	public void when_insert_and_commit_vertex__then_it_should_be_committed_and_stored_in_engine() throws VertexInsertionException, RadixEngineException {
+	public void when_insert_and_commit_vertex__then_it_should_be_committed_and_stored_in_engine()
+		throws VertexInsertionException, RadixEngineException {
 		Vertex nextVertex = Vertex.createVertex(rootQC, View.of(1), mock(Atom.class));
 		vertexStore.insertVertex(nextVertex);
 		TestObserver<Vertex> testObserver = TestObserver.create();
@@ -143,7 +146,8 @@ public class VertexStoreTest {
 	}
 
 	@Test
-	public void when_insert_two_vertices__then_get_path_from_root_should_return_the_two_vertices() throws Exception {
+	public void when_insert_two_vertices__then_get_path_from_root_should_return_the_two_vertices()
+		throws Exception {
 		Vertex nextVertex0 = Vertex.createVertex(rootQC, View.of(1), null);
 		VertexMetadata vertexMetadata = new VertexMetadata(View.of(1), nextVertex0.getId());
 		VoteData voteData = new VoteData(vertexMetadata, rootQC.getProposed());
@@ -156,7 +160,8 @@ public class VertexStoreTest {
 	}
 
 	@Test
-	public void when_insert_and_commit_vertex__then_committed_vertex_should_emit_and_store_should_have_size_1() throws Exception {
+	public void when_insert_and_commit_vertex__then_committed_vertex_should_emit_and_store_should_have_size_1()
+		throws Exception {
 		Vertex nextVertex = Vertex.createVertex(rootQC, View.of(1), null);
 		vertexStore.insertVertex(nextVertex);
 
@@ -171,7 +176,8 @@ public class VertexStoreTest {
 	}
 
 	@Test
-	public void when_insert_and_commit_vertex_2x__then_committed_vertex_should_emit_in_order_and_store_should_have_size_1() throws Exception {
+	public void when_insert_and_commit_vertex_2x__then_committed_vertex_should_emit_in_order_and_store_should_have_size_1()
+		throws Exception {
 		TestObserver<Vertex> testObserver = TestObserver.create();
 		vertexStore.lastCommittedVertex().subscribe(testObserver);
 		Vertex nextVertex = Vertex.createVertex(rootQC, View.of(1), null);
@@ -190,7 +196,8 @@ public class VertexStoreTest {
 	}
 
 	@Test
-	public void when_insert_two_and_commit_vertex__then_two_committed_vertices_should_emit_in_order_and_store_should_have_size_1() throws Exception {
+	public void when_insert_two_and_commit_vertex__then_two_committed_vertices_should_emit_in_order_and_store_should_have_size_1()
+		throws Exception {
 		Vertex nextVertex = Vertex.createVertex(rootQC, View.of(1), null);
 		vertexStore.insertVertex(nextVertex);
 


### PR DESCRIPTION
Ensure that only actually committed atoms are returned by the API by changing the `VertexStore` implementation to only store atoms if they were committed (rather than just inserted).