### PR TITLE
Refactor atoms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 sudo: false
 install: true
+jdk: openjdk8
 
 addons:
   sonarcloud:

--- a/radixdlt/build.gradle
+++ b/radixdlt/build.gradle
@@ -83,7 +83,7 @@ jacocoTestReport {
 }
 
 dependencies {
-    compile ('com.radixdlt:radix-engine-library:1.0-beta.9')
+    compile 'com.radixdlt:radix-engine-library:infrastructure~generic-atom-SNAPSHOT'
 
     compile 'io.reactivex.rxjava3:rxjava:3.0.0'
     compile 'com.sleepycat:je:18.3.12'

--- a/radixdlt/src/integration/java/com/radixdlt/consensus/simulation/SimulatedBFTNetwork.java
+++ b/radixdlt/src/integration/java/com/radixdlt/consensus/simulation/SimulatedBFTNetwork.java
@@ -17,9 +17,7 @@
 
 package com.radixdlt.consensus.simulation;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import com.radixdlt.consensus.ConsensusRunner;
@@ -53,6 +51,7 @@ import com.radixdlt.engine.RadixEngine;
 import com.radixdlt.mempool.EmptyMempool;
 import com.radixdlt.mempool.Mempool;
 
+import com.radixdlt.middleware2.LedgerAtom;
 import com.radixdlt.middleware2.network.TestEventCoordinatorNetwork;
 import com.radixdlt.utils.UInt256;
 import io.reactivex.rxjava3.core.Completable;
@@ -61,7 +60,6 @@ import io.reactivex.rxjava3.subjects.CompletableSubject;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
@@ -118,8 +116,7 @@ public class SimulatedBFTNetwork {
 			.collect(ImmutableMap.toImmutableMap(
 				e -> e,
 				e -> {
-					RadixEngine radixEngine = mock(RadixEngine.class);
-					when(radixEngine.staticCheck(any())).thenReturn(Optional.empty());
+					RadixEngine<LedgerAtom> radixEngine = mock(RadixEngine.class);
 					return new VertexStore(genesisVertex, genesisQC, radixEngine, this.counters.get(e));
 				})
 			);

--- a/radixdlt/src/main/java/com/radixdlt/CerberusModule.java
+++ b/radixdlt/src/main/java/com/radixdlt/CerberusModule.java
@@ -140,7 +140,7 @@ public class CerberusModule extends AbstractModule {
 			throw new IllegalStateException("Can only support one genesis atom.");
 		}
 
-		LedgerAtom genesisAtom = LedgerAtom.convert(universe.getGenesis().get(0));
+		final LedgerAtom genesisAtom = LedgerAtom.convertFromApiAtom(universe.getGenesis().get(0));
 		final Vertex genesisVertex = Vertex.createGenesis(genesisAtom);
 		final VertexMetadata genesisMetadata = new VertexMetadata(View.genesis(), genesisVertex.getId(), 0);
 		final VoteData voteData = new VoteData(genesisMetadata, null);

--- a/radixdlt/src/main/java/com/radixdlt/CerberusModule.java
+++ b/radixdlt/src/main/java/com/radixdlt/CerberusModule.java
@@ -51,9 +51,8 @@ import com.radixdlt.counters.SystemCounters;
 import com.radixdlt.crypto.ECDSASignatures;
 import com.radixdlt.crypto.ECKeyPair;
 import com.radixdlt.engine.RadixEngine;
-import com.radixdlt.middleware.RadixEngineUtils;
-import com.radixdlt.middleware.RadixEngineUtils.CMAtomConversionException;
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
+import com.radixdlt.middleware2.LedgerAtom.CMAtomConversionException;
 import com.radixdlt.middleware2.network.MessageCentralBFTNetwork;
 import com.radixdlt.network.addressbook.AddressBook;
 import com.radixdlt.properties.RuntimeProperties;
@@ -133,7 +132,7 @@ public class CerberusModule extends AbstractModule {
 	@Singleton
 	private VertexStore getVertexStore(
 		Universe universe,
-		RadixEngine<SimpleRadixEngineAtom> radixEngine,
+		RadixEngine<LedgerAtom> radixEngine,
 		SystemCounters counters,
 		VertexSupplier vertexSupplier
 	) throws CMAtomConversionException {
@@ -141,7 +140,7 @@ public class CerberusModule extends AbstractModule {
 			throw new IllegalStateException("Can only support one genesis atom.");
 		}
 
-		SimpleRadixEngineAtom genesisAtom = RadixEngineUtils.toCMAtom(universe.getGenesis().get(0));
+		LedgerAtom genesisAtom = LedgerAtom.convert(universe.getGenesis().get(0));
 		final Vertex genesisVertex = Vertex.createGenesis(genesisAtom);
 		final VertexMetadata genesisMetadata = new VertexMetadata(View.genesis(), genesisVertex.getId(), 0);
 		final VoteData voteData = new VoteData(genesisMetadata, null);

--- a/radixdlt/src/main/java/com/radixdlt/CerberusModule.java
+++ b/radixdlt/src/main/java/com/radixdlt/CerberusModule.java
@@ -52,7 +52,7 @@ import com.radixdlt.crypto.ECDSASignatures;
 import com.radixdlt.crypto.ECKeyPair;
 import com.radixdlt.engine.RadixEngine;
 import com.radixdlt.middleware2.LedgerAtom;
-import com.radixdlt.middleware2.LedgerAtom.CMAtomConversionException;
+import com.radixdlt.middleware2.LedgerAtom.LedgerAtomConversionException;
 import com.radixdlt.middleware2.network.MessageCentralBFTNetwork;
 import com.radixdlt.network.addressbook.AddressBook;
 import com.radixdlt.properties.RuntimeProperties;
@@ -135,7 +135,7 @@ public class CerberusModule extends AbstractModule {
 		RadixEngine<LedgerAtom> radixEngine,
 		SystemCounters counters,
 		VertexSupplier vertexSupplier
-	) throws CMAtomConversionException {
+	) throws LedgerAtomConversionException {
 		if (universe.getGenesis().size() != 1) {
 			throw new IllegalStateException("Can only support one genesis atom.");
 		}

--- a/radixdlt/src/main/java/com/radixdlt/CerberusModule.java
+++ b/radixdlt/src/main/java/com/radixdlt/CerberusModule.java
@@ -51,6 +51,9 @@ import com.radixdlt.counters.SystemCounters;
 import com.radixdlt.crypto.ECDSASignatures;
 import com.radixdlt.crypto.ECKeyPair;
 import com.radixdlt.engine.RadixEngine;
+import com.radixdlt.middleware.RadixEngineUtils;
+import com.radixdlt.middleware.RadixEngineUtils.CMAtomConversionException;
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 import com.radixdlt.middleware2.network.MessageCentralBFTNetwork;
 import com.radixdlt.network.addressbook.AddressBook;
 import com.radixdlt.properties.RuntimeProperties;
@@ -130,15 +133,16 @@ public class CerberusModule extends AbstractModule {
 	@Singleton
 	private VertexStore getVertexStore(
 		Universe universe,
-		RadixEngine radixEngine,
+		RadixEngine<SimpleRadixEngineAtom> radixEngine,
 		SystemCounters counters,
 		VertexSupplier vertexSupplier
-	) {
+	) throws CMAtomConversionException {
 		if (universe.getGenesis().size() != 1) {
 			throw new IllegalStateException("Can only support one genesis atom.");
 		}
 
-		final Vertex genesisVertex = Vertex.createGenesis(universe.getGenesis().get(0));
+		SimpleRadixEngineAtom genesisAtom = RadixEngineUtils.toCMAtom(universe.getGenesis().get(0));
+		final Vertex genesisVertex = Vertex.createGenesis(genesisAtom);
 		final VertexMetadata genesisMetadata = new VertexMetadata(View.genesis(), genesisVertex.getId(), 0);
 		final VoteData voteData = new VoteData(genesisMetadata, null);
 		final QuorumCertificate rootQC = new QuorumCertificate(voteData, new ECDSASignatures());

--- a/radixdlt/src/main/java/com/radixdlt/consensus/BFTEventReducer.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/BFTEventReducer.java
@@ -19,7 +19,6 @@ package com.radixdlt.consensus;
 
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
-import com.radixdlt.atommodel.Atom;
 import com.radixdlt.consensus.liveness.ProposalGenerator;
 import com.radixdlt.identifiers.EUID;
 import com.radixdlt.consensus.liveness.Pacemaker;
@@ -34,6 +33,7 @@ import com.radixdlt.crypto.ECKeyPair;
 import com.radixdlt.crypto.ECPublicKey;
 import com.radixdlt.crypto.Hash;
 import com.radixdlt.mempool.Mempool;
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 import com.radixdlt.utils.Longs;
 
 import java.util.HashMap;
@@ -117,7 +117,7 @@ public final class BFTEventReducer implements BFTEventProcessor {
 			.ifPresent(vertexId -> {
 				final Vertex vertex = vertexStore.commitVertex(vertexId);
 				log.info("{}: Committed vertex: {}", this.getShortName(), vertex);
-				final Atom committedAtom = vertex.getAtom();
+				final SimpleRadixEngineAtom committedAtom = vertex.getAtom();
 				if (committedAtom != null) {
 					mempool.removeCommittedAtom(committedAtom.getAID());
 				}
@@ -195,7 +195,7 @@ public final class BFTEventReducer implements BFTEventProcessor {
 			log.info(String.format("%s: PROPOSAL: Rejected", this.getShortName()), e);
 
 			// TODO: Better logic for removal on exception
-			final Atom atom = proposedVertex.getAtom();
+			final SimpleRadixEngineAtom atom = proposedVertex.getAtom();
 			if (atom != null) {
 				mempool.removeRejectedAtom(atom.getAID());
 			}

--- a/radixdlt/src/main/java/com/radixdlt/consensus/BFTEventReducer.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/BFTEventReducer.java
@@ -33,7 +33,7 @@ import com.radixdlt.crypto.ECKeyPair;
 import com.radixdlt.crypto.ECPublicKey;
 import com.radixdlt.crypto.Hash;
 import com.radixdlt.mempool.Mempool;
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
 import com.radixdlt.utils.Longs;
 
 import java.util.HashMap;
@@ -117,7 +117,7 @@ public final class BFTEventReducer implements BFTEventProcessor {
 			.ifPresent(vertexId -> {
 				final Vertex vertex = vertexStore.commitVertex(vertexId);
 				log.info("{}: Committed vertex: {}", this.getShortName(), vertex);
-				final SimpleRadixEngineAtom committedAtom = vertex.getAtom();
+				final LedgerAtom committedAtom = vertex.getAtom();
 				if (committedAtom != null) {
 					mempool.removeCommittedAtom(committedAtom.getAID());
 				}
@@ -195,7 +195,7 @@ public final class BFTEventReducer implements BFTEventProcessor {
 			log.info(String.format("%s: PROPOSAL: Rejected", this.getShortName()), e);
 
 			// TODO: Better logic for removal on exception
-			final SimpleRadixEngineAtom atom = proposedVertex.getAtom();
+			final LedgerAtom atom = proposedVertex.getAtom();
 			if (atom != null) {
 				mempool.removeRejectedAtom(atom.getAID());
 			}

--- a/radixdlt/src/main/java/com/radixdlt/consensus/Vertex.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/Vertex.java
@@ -163,8 +163,8 @@ public final class Vertex {
 		}
 
 		Vertex v = (Vertex) o;
-		return Objects.equals(v.view, view)
-			&& Objects.equals(v.atom, atom)
+		return Objects.equals(v.view, this.view)
+			&& Objects.equals(v.atom, this.atom)
 			&& Objects.equals(v.qc, this.qc);
 	}
 }

--- a/radixdlt/src/main/java/com/radixdlt/consensus/VertexStore.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/VertexStore.java
@@ -23,7 +23,7 @@ import com.radixdlt.crypto.Hash;
 import com.radixdlt.engine.RadixEngine;
 import com.radixdlt.engine.RadixEngineException;
 
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.subjects.BehaviorSubject;
 import java.util.ArrayList;
@@ -40,7 +40,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * TODO: make thread-safe
  */
 public final class VertexStore {
-	private final RadixEngine<SimpleRadixEngineAtom> engine;
+	private final RadixEngine<LedgerAtom> engine;
 	private final SystemCounters counters;
 	private final Map<Hash, Vertex> vertices = new ConcurrentHashMap<>();
 	private final BehaviorSubject<Vertex> lastCommittedVertex = BehaviorSubject.create();
@@ -55,7 +55,7 @@ public final class VertexStore {
 	public VertexStore(
 		Vertex genesisVertex,
 		QuorumCertificate rootQC,
-		RadixEngine<SimpleRadixEngineAtom> engine,
+		RadixEngine<LedgerAtom> engine,
 		SystemCounters counters
 	) {
 		this.engine = Objects.requireNonNull(engine);

--- a/radixdlt/src/main/java/com/radixdlt/consensus/VertexStore.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/VertexStore.java
@@ -23,6 +23,7 @@ import com.radixdlt.crypto.Hash;
 import com.radixdlt.engine.RadixEngine;
 import com.radixdlt.engine.RadixEngineException;
 
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.subjects.BehaviorSubject;
 import java.util.ArrayList;
@@ -40,7 +41,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * TODO: make thread-safe
  */
 public final class VertexStore {
-	private final RadixEngine engine;
+	private final RadixEngine<SimpleRadixEngineAtom> engine;
 	private final SystemCounters counters;
 	private final Map<Hash, Vertex> vertices = new ConcurrentHashMap<>();
 	private final BehaviorSubject<Vertex> lastCommittedVertex = BehaviorSubject.create();
@@ -54,7 +55,7 @@ public final class VertexStore {
 	public VertexStore(
 		Vertex genesisVertex,
 		QuorumCertificate rootQC,
-		RadixEngine engine,
+		RadixEngine<SimpleRadixEngineAtom> engine,
 		SystemCounters counters
 	) {
 		this.engine = Objects.requireNonNull(engine);

--- a/radixdlt/src/main/java/com/radixdlt/consensus/liveness/MempoolProposalGenerator.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/liveness/MempoolProposalGenerator.java
@@ -18,12 +18,12 @@
 package com.radixdlt.consensus.liveness;
 
 import com.radixdlt.identifiers.AID;
-import com.radixdlt.atommodel.Atom;
 import com.radixdlt.consensus.QuorumCertificate;
 import com.radixdlt.consensus.Vertex;
 import com.radixdlt.consensus.VertexStore;
 import com.radixdlt.consensus.View;
 import com.radixdlt.mempool.Mempool;
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -54,10 +54,10 @@ public final class MempoolProposalGenerator implements ProposalGenerator {
 		final Set<AID> preparedAtoms = preparedVertices.stream()
 			.map(Vertex::getAtom)
 			.filter(Objects::nonNull)
-			.map(Atom::getAID)
+			.map(SimpleRadixEngineAtom::getAID)
 			.collect(Collectors.toSet());
 
-		final List<Atom> atoms = mempool.getAtoms(1, preparedAtoms);
+		final List<SimpleRadixEngineAtom> atoms = mempool.getAtoms(1, preparedAtoms);
 
 		return Vertex.createVertex(highestQC, view, !atoms.isEmpty() ? atoms.get(0) : null);
 	}

--- a/radixdlt/src/main/java/com/radixdlt/consensus/liveness/MempoolProposalGenerator.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/liveness/MempoolProposalGenerator.java
@@ -23,7 +23,7 @@ import com.radixdlt.consensus.Vertex;
 import com.radixdlt.consensus.VertexStore;
 import com.radixdlt.consensus.View;
 import com.radixdlt.mempool.Mempool;
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -54,10 +54,10 @@ public final class MempoolProposalGenerator implements ProposalGenerator {
 		final Set<AID> preparedAtoms = preparedVertices.stream()
 			.map(Vertex::getAtom)
 			.filter(Objects::nonNull)
-			.map(SimpleRadixEngineAtom::getAID)
+			.map(LedgerAtom::getAID)
 			.collect(Collectors.toSet());
 
-		final List<SimpleRadixEngineAtom> atoms = mempool.getAtoms(1, preparedAtoms);
+		final List<LedgerAtom> atoms = mempool.getAtoms(1, preparedAtoms);
 
 		return Vertex.createVertex(highestQC, view, !atoms.isEmpty() ? atoms.get(0) : null);
 	}

--- a/radixdlt/src/main/java/com/radixdlt/mempool/EmptyMempool.java
+++ b/radixdlt/src/main/java/com/radixdlt/mempool/EmptyMempool.java
@@ -17,8 +17,8 @@
 
 package com.radixdlt.mempool;
 
-import com.radixdlt.atommodel.Atom;
 import com.radixdlt.identifiers.AID;
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -29,7 +29,7 @@ import java.util.Set;
 public class EmptyMempool implements Mempool {
 
 	@Override
-	public void addAtom(Atom atom) {
+	public void addAtom(SimpleRadixEngineAtom atom) {
 		// No-op
 	}
 
@@ -44,7 +44,7 @@ public class EmptyMempool implements Mempool {
 	}
 
 	@Override
-	public List<Atom> getAtoms(int count, Set<AID> seen) {
+	public List<SimpleRadixEngineAtom> getAtoms(int count, Set<AID> seen) {
 		return Collections.emptyList();
 	}
 

--- a/radixdlt/src/main/java/com/radixdlt/mempool/EmptyMempool.java
+++ b/radixdlt/src/main/java/com/radixdlt/mempool/EmptyMempool.java
@@ -18,7 +18,7 @@
 package com.radixdlt.mempool;
 
 import com.radixdlt.identifiers.AID;
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -29,7 +29,7 @@ import java.util.Set;
 public class EmptyMempool implements Mempool {
 
 	@Override
-	public void addAtom(SimpleRadixEngineAtom atom) {
+	public void addAtom(LedgerAtom atom) {
 		// No-op
 	}
 
@@ -44,7 +44,7 @@ public class EmptyMempool implements Mempool {
 	}
 
 	@Override
-	public List<SimpleRadixEngineAtom> getAtoms(int count, Set<AID> seen) {
+	public List<LedgerAtom> getAtoms(int count, Set<AID> seen) {
 		return Collections.emptyList();
 	}
 

--- a/radixdlt/src/main/java/com/radixdlt/mempool/LocalMempool.java
+++ b/radixdlt/src/main/java/com/radixdlt/mempool/LocalMempool.java
@@ -16,7 +16,7 @@
  */
 package com.radixdlt.mempool;
 
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -39,7 +39,7 @@ import com.radixdlt.properties.RuntimeProperties;
 final class LocalMempool implements Mempool {
 	private final Object lock = new Object();
 	@GuardedBy("lock")
-	private final LinkedHashMap<AID, SimpleRadixEngineAtom> data = Maps.newLinkedHashMap();
+	private final LinkedHashMap<AID, LedgerAtom> data = Maps.newLinkedHashMap();
 
 	private final int maxSize;
 
@@ -56,7 +56,7 @@ final class LocalMempool implements Mempool {
 	}
 
 	@Override
-	public void addAtom(SimpleRadixEngineAtom atom) throws MempoolFullException, MempoolDuplicateException {
+	public void addAtom(LedgerAtom atom) throws MempoolFullException, MempoolDuplicateException {
 		synchronized (this.lock) {
 			if (this.data.size() >= this.maxSize) {
 				throw new MempoolFullException(atom, String.format("Mempool full: %s of %s items", this.data.size(), this.maxSize));
@@ -83,14 +83,14 @@ final class LocalMempool implements Mempool {
 	}
 
 	@Override
-	public List<SimpleRadixEngineAtom> getAtoms(int count, Set<AID> seen) {
+	public List<LedgerAtom> getAtoms(int count, Set<AID> seen) {
 		synchronized (this.lock) {
 			int size = Math.min(count, this.data.size());
 			if (size > 0) {
-				List<SimpleRadixEngineAtom> atoms = Lists.newArrayList();
-				Iterator<SimpleRadixEngineAtom> i = this.data.values().iterator();
+				List<LedgerAtom> atoms = Lists.newArrayList();
+				Iterator<LedgerAtom> i = this.data.values().iterator();
 				while (atoms.size() < size && i.hasNext()) {
-					SimpleRadixEngineAtom a = i.next();
+					LedgerAtom a = i.next();
 					if (seen.add(a.getAID())) {
 						atoms.add(a);
 					}

--- a/radixdlt/src/main/java/com/radixdlt/mempool/LocalMempool.java
+++ b/radixdlt/src/main/java/com/radixdlt/mempool/LocalMempool.java
@@ -16,6 +16,7 @@
  */
 package com.radixdlt.mempool;
 
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -27,7 +28,6 @@ import javax.inject.Inject;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.radixdlt.identifiers.AID;
-import com.radixdlt.atommodel.Atom;
 import com.radixdlt.properties.RuntimeProperties;
 
 /**
@@ -39,7 +39,7 @@ import com.radixdlt.properties.RuntimeProperties;
 final class LocalMempool implements Mempool {
 	private final Object lock = new Object();
 	@GuardedBy("lock")
-	private final LinkedHashMap<AID, Atom> data = Maps.newLinkedHashMap();
+	private final LinkedHashMap<AID, SimpleRadixEngineAtom> data = Maps.newLinkedHashMap();
 
 	private final int maxSize;
 
@@ -56,7 +56,7 @@ final class LocalMempool implements Mempool {
 	}
 
 	@Override
-	public void addAtom(Atom atom) throws MempoolFullException, MempoolDuplicateException {
+	public void addAtom(SimpleRadixEngineAtom atom) throws MempoolFullException, MempoolDuplicateException {
 		synchronized (this.lock) {
 			if (this.data.size() >= this.maxSize) {
 				throw new MempoolFullException(atom, String.format("Mempool full: %s of %s items", this.data.size(), this.maxSize));
@@ -83,14 +83,14 @@ final class LocalMempool implements Mempool {
 	}
 
 	@Override
-	public List<Atom> getAtoms(int count, Set<AID> seen) {
+	public List<SimpleRadixEngineAtom> getAtoms(int count, Set<AID> seen) {
 		synchronized (this.lock) {
 			int size = Math.min(count, this.data.size());
 			if (size > 0) {
-				List<Atom> atoms = Lists.newArrayList();
-				Iterator<Atom> i = this.data.values().iterator();
+				List<SimpleRadixEngineAtom> atoms = Lists.newArrayList();
+				Iterator<SimpleRadixEngineAtom> i = this.data.values().iterator();
 				while (atoms.size() < size && i.hasNext()) {
-					Atom a = i.next();
+					SimpleRadixEngineAtom a = i.next();
 					if (seen.add(a.getAID())) {
 						atoms.add(a);
 					}

--- a/radixdlt/src/main/java/com/radixdlt/mempool/Mempool.java
+++ b/radixdlt/src/main/java/com/radixdlt/mempool/Mempool.java
@@ -16,7 +16,7 @@
  */
 package com.radixdlt.mempool;
 
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
 import java.util.List;
 import java.util.Set;
 
@@ -27,7 +27,7 @@ import com.radixdlt.identifiers.AID;
  * Implementations are expected to be thread safe.
  * <p>
  * Note that conceptually, a mempoolcan be thought of as a list indexable
- * by {@link AID} and ordered FIFO by {@link #addAtom(SimpleRadixEngineAtom)} call order.
+ * by {@link AID} and ordered FIFO by {@link #addAtom(LedgerAtom)} call order.
  */
 public interface Mempool {
 	/**
@@ -38,7 +38,7 @@ public interface Mempool {
 	 * @throws MempoolFullException if the mempool cannot accept new submissions.
 	 * @throws MempoolDuplicateException if the mempool already has the specified atom
 	 */
-	void addAtom(SimpleRadixEngineAtom atom) throws MempoolFullException, MempoolDuplicateException;
+	void addAtom(LedgerAtom atom) throws MempoolFullException, MempoolDuplicateException;
 
 	/**
 	 * Remove the referenced atom from the local mempool after it has
@@ -67,7 +67,7 @@ public interface Mempool {
 	 * @param seen IDs of atoms seen by consensus, but not yet committed to the ledger
 	 * @return A list of atoms for processing by consensus
 	 */
-	List<SimpleRadixEngineAtom> getAtoms(int count, Set<AID> seen);
+	List<LedgerAtom> getAtoms(int count, Set<AID> seen);
 
 	/**
 	 * Return approximate count of atoms in the mempool.

--- a/radixdlt/src/main/java/com/radixdlt/mempool/Mempool.java
+++ b/radixdlt/src/main/java/com/radixdlt/mempool/Mempool.java
@@ -16,8 +16,7 @@
  */
 package com.radixdlt.mempool;
 
-import com.radixdlt.atommodel.Atom;
-
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 import java.util.List;
 import java.util.Set;
 
@@ -28,7 +27,7 @@ import com.radixdlt.identifiers.AID;
  * Implementations are expected to be thread safe.
  * <p>
  * Note that conceptually, a mempoolcan be thought of as a list indexable
- * by {@link AID} and ordered FIFO by {@link #addAtom(Atom)} call order.
+ * by {@link AID} and ordered FIFO by {@link #addAtom(SimpleRadixEngineAtom)} call order.
  */
 public interface Mempool {
 	/**
@@ -39,7 +38,7 @@ public interface Mempool {
 	 * @throws MempoolFullException if the mempool cannot accept new submissions.
 	 * @throws MempoolDuplicateException if the mempool already has the specified atom
 	 */
-	void addAtom(Atom atom) throws MempoolFullException, MempoolDuplicateException;
+	void addAtom(SimpleRadixEngineAtom atom) throws MempoolFullException, MempoolDuplicateException;
 
 	/**
 	 * Remove the referenced atom from the local mempool after it has
@@ -68,7 +67,7 @@ public interface Mempool {
 	 * @param seen IDs of atoms seen by consensus, but not yet committed to the ledger
 	 * @return A list of atoms for processing by consensus
 	 */
-	List<Atom> getAtoms(int count, Set<AID> seen);
+	List<SimpleRadixEngineAtom> getAtoms(int count, Set<AID> seen);
 
 	/**
 	 * Return approximate count of atoms in the mempool.

--- a/radixdlt/src/main/java/com/radixdlt/mempool/MempoolFullException.java
+++ b/radixdlt/src/main/java/com/radixdlt/mempool/MempoolFullException.java
@@ -17,14 +17,14 @@
 
 package com.radixdlt.mempool;
 
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
 
 /**
  * Exception thrown when an attempt to add new items would
  * exceed the mempool's maximum capacity.
  */
 public class MempoolFullException extends MempoolRejectedException {
-	public MempoolFullException(SimpleRadixEngineAtom atom, String message) {
+	public MempoolFullException(LedgerAtom atom, String message) {
 		super(atom, message);
 	}
 }

--- a/radixdlt/src/main/java/com/radixdlt/mempool/MempoolFullException.java
+++ b/radixdlt/src/main/java/com/radixdlt/mempool/MempoolFullException.java
@@ -17,14 +17,14 @@
 
 package com.radixdlt.mempool;
 
-import com.radixdlt.atommodel.Atom;
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 
 /**
  * Exception thrown when an attempt to add new items would
  * exceed the mempool's maximum capacity.
  */
 public class MempoolFullException extends MempoolRejectedException {
-	public MempoolFullException(Atom atom, String message) {
+	public MempoolFullException(SimpleRadixEngineAtom atom, String message) {
 		super(atom, message);
 	}
 }

--- a/radixdlt/src/main/java/com/radixdlt/mempool/MempoolModule.java
+++ b/radixdlt/src/main/java/com/radixdlt/mempool/MempoolModule.java
@@ -39,7 +39,7 @@ public class MempoolModule extends AbstractModule {
 	private AtomToLedgerAtomConverter converter() {
 		return atom -> {
 			try {
-				return LedgerAtom.convert(atom);
+				return LedgerAtom.convertFromApiAtom(atom);
 			} catch (LedgerAtomConversionException e) {
 				throw new AtomConversionException(e.getDataPointer(), e);
 			}

--- a/radixdlt/src/main/java/com/radixdlt/mempool/MempoolModule.java
+++ b/radixdlt/src/main/java/com/radixdlt/mempool/MempoolModule.java
@@ -18,7 +18,13 @@
 package com.radixdlt.mempool;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
 import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+import com.radixdlt.middleware.RadixEngineUtils;
+import com.radixdlt.middleware.RadixEngineUtils.CMAtomConversionException;
+import com.radixdlt.middleware2.converters.AtomConversionException;
+import com.radixdlt.middleware2.converters.AtomToRadixEngineAtomConverter;
 
 public class MempoolModule extends AbstractModule {
 	@Override
@@ -26,5 +32,17 @@ public class MempoolModule extends AbstractModule {
 		// provides
 		bind(Mempool.class).to(SharedMempool.class).in(Scopes.SINGLETON);
 		bind(SubmissionControl.class).to(SubmissionControlImpl.class).in(Scopes.SINGLETON);
+	}
+
+	@Provides
+	@Singleton
+	private AtomToRadixEngineAtomConverter converter() {
+		return atom -> {
+			try {
+				return RadixEngineUtils.toCMAtom(atom);
+			} catch (CMAtomConversionException e) {
+				throw new AtomConversionException(e);
+			}
+		};
 	}
 }

--- a/radixdlt/src/main/java/com/radixdlt/mempool/MempoolModule.java
+++ b/radixdlt/src/main/java/com/radixdlt/mempool/MempoolModule.java
@@ -22,7 +22,7 @@ import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import com.radixdlt.middleware2.LedgerAtom;
-import com.radixdlt.middleware2.LedgerAtom.CMAtomConversionException;
+import com.radixdlt.middleware2.LedgerAtom.LedgerAtomConversionException;
 import com.radixdlt.middleware2.converters.AtomConversionException;
 import com.radixdlt.middleware2.converters.AtomToLedgerAtomConverter;
 
@@ -40,7 +40,7 @@ public class MempoolModule extends AbstractModule {
 		return atom -> {
 			try {
 				return LedgerAtom.convert(atom);
-			} catch (CMAtomConversionException e) {
+			} catch (LedgerAtomConversionException e) {
 				throw new AtomConversionException(e.getDataPointer(), e);
 			}
 		};

--- a/radixdlt/src/main/java/com/radixdlt/mempool/MempoolModule.java
+++ b/radixdlt/src/main/java/com/radixdlt/mempool/MempoolModule.java
@@ -21,10 +21,10 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
-import com.radixdlt.middleware.RadixEngineUtils;
-import com.radixdlt.middleware.RadixEngineUtils.CMAtomConversionException;
+import com.radixdlt.middleware2.LedgerAtom;
+import com.radixdlt.middleware2.LedgerAtom.CMAtomConversionException;
 import com.radixdlt.middleware2.converters.AtomConversionException;
-import com.radixdlt.middleware2.converters.AtomToRadixEngineAtomConverter;
+import com.radixdlt.middleware2.converters.AtomToLedgerAtomConverter;
 
 public class MempoolModule extends AbstractModule {
 	@Override
@@ -36,10 +36,10 @@ public class MempoolModule extends AbstractModule {
 
 	@Provides
 	@Singleton
-	private AtomToRadixEngineAtomConverter converter() {
+	private AtomToLedgerAtomConverter converter() {
 		return atom -> {
 			try {
-				return RadixEngineUtils.toCMAtom(atom);
+				return LedgerAtom.convert(atom);
 			} catch (CMAtomConversionException e) {
 				throw new AtomConversionException(e.getDataPointer(), e);
 			}

--- a/radixdlt/src/main/java/com/radixdlt/mempool/MempoolModule.java
+++ b/radixdlt/src/main/java/com/radixdlt/mempool/MempoolModule.java
@@ -41,7 +41,7 @@ public class MempoolModule extends AbstractModule {
 			try {
 				return RadixEngineUtils.toCMAtom(atom);
 			} catch (CMAtomConversionException e) {
-				throw new AtomConversionException(e);
+				throw new AtomConversionException(e.getDataPointer(), e);
 			}
 		};
 	}

--- a/radixdlt/src/main/java/com/radixdlt/mempool/MempoolNetworkRx.java
+++ b/radixdlt/src/main/java/com/radixdlt/mempool/MempoolNetworkRx.java
@@ -17,7 +17,7 @@
 
 package com.radixdlt.mempool;
 
-import com.radixdlt.atommodel.Atom;
+import com.radixdlt.middleware2.LedgerAtom;
 import io.reactivex.rxjava3.core.Observable;
 
 /**
@@ -31,5 +31,5 @@ public interface MempoolNetworkRx {
 	 *
 	 * @return hot observable of atom messages
 	 */
-	Observable<Atom> atomMessages();
+	Observable<LedgerAtom> atomMessages();
 }

--- a/radixdlt/src/main/java/com/radixdlt/mempool/MempoolNetworkTx.java
+++ b/radixdlt/src/main/java/com/radixdlt/mempool/MempoolNetworkTx.java
@@ -17,7 +17,7 @@
 
 package com.radixdlt.mempool;
 
-import com.radixdlt.atommodel.Atom;
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 
 /**
  * Interface for Mempool to send things through a network
@@ -28,5 +28,5 @@ public interface MempoolNetworkTx {
 	 *
 	 * @param atom the submission to send
 	 */
-	void sendMempoolSubmission(Atom atom);
+	void sendMempoolSubmission(SimpleRadixEngineAtom atom);
 }

--- a/radixdlt/src/main/java/com/radixdlt/mempool/MempoolNetworkTx.java
+++ b/radixdlt/src/main/java/com/radixdlt/mempool/MempoolNetworkTx.java
@@ -17,7 +17,7 @@
 
 package com.radixdlt.mempool;
 
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
 
 /**
  * Interface for Mempool to send things through a network
@@ -28,5 +28,5 @@ public interface MempoolNetworkTx {
 	 *
 	 * @param atom the submission to send
 	 */
-	void sendMempoolSubmission(SimpleRadixEngineAtom atom);
+	void sendMempoolSubmission(LedgerAtom atom);
 }

--- a/radixdlt/src/main/java/com/radixdlt/mempool/MempoolReceiver.java
+++ b/radixdlt/src/main/java/com/radixdlt/mempool/MempoolReceiver.java
@@ -17,10 +17,10 @@
 
 package com.radixdlt.mempool;
 
+import com.radixdlt.middleware2.LedgerAtom;
 import java.util.Objects;
 
 import com.google.inject.Inject;
-import com.radixdlt.atommodel.Atom;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -74,7 +74,7 @@ public final class MempoolReceiver {
 		}
 	}
 
-	private void processAtom(Atom atom) {
+	private void processAtom(LedgerAtom atom) {
 		try {
 			this.submissionControl.submitAtom(atom);
 		} catch (MempoolRejectedException ex) {

--- a/radixdlt/src/main/java/com/radixdlt/mempool/MempoolRejectedException.java
+++ b/radixdlt/src/main/java/com/radixdlt/mempool/MempoolRejectedException.java
@@ -17,21 +17,21 @@
 
 package com.radixdlt.mempool;
 
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
 
 /**
  * Exception thrown when mempool rejects an atom.
  */
 public class MempoolRejectedException extends Exception {
 
-	private final SimpleRadixEngineAtom atom;
+	private final LedgerAtom atom;
 
-	public MempoolRejectedException(SimpleRadixEngineAtom atom, String message) {
+	public MempoolRejectedException(LedgerAtom atom, String message) {
 		super(message);
 		this.atom = atom;
 	}
 
-	public SimpleRadixEngineAtom atom() {
+	public LedgerAtom atom() {
 		return atom;
 	}
 }

--- a/radixdlt/src/main/java/com/radixdlt/mempool/MempoolRejectedException.java
+++ b/radixdlt/src/main/java/com/radixdlt/mempool/MempoolRejectedException.java
@@ -17,21 +17,21 @@
 
 package com.radixdlt.mempool;
 
-import com.radixdlt.atommodel.Atom;
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 
 /**
  * Exception thrown when mempool rejects an atom.
  */
 public class MempoolRejectedException extends Exception {
 
-	private final Atom atom;
+	private final SimpleRadixEngineAtom atom;
 
-	public MempoolRejectedException(Atom atom, String message) {
+	public MempoolRejectedException(SimpleRadixEngineAtom atom, String message) {
 		super(message);
 		this.atom = atom;
 	}
 
-	public Atom atom() {
+	public SimpleRadixEngineAtom atom() {
 		return atom;
 	}
 }

--- a/radixdlt/src/main/java/com/radixdlt/mempool/SharedMempool.java
+++ b/radixdlt/src/main/java/com/radixdlt/mempool/SharedMempool.java
@@ -17,7 +17,7 @@
 
 package com.radixdlt.mempool;
 
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -47,7 +47,7 @@ public class SharedMempool implements Mempool {
 	}
 
 	@Override
-	public void addAtom(SimpleRadixEngineAtom atom) throws MempoolFullException, MempoolDuplicateException {
+	public void addAtom(LedgerAtom atom) throws MempoolFullException, MempoolDuplicateException {
 		this.localMempool.addAtom(atom);
 		updateCounts();
 		this.networkSender.sendMempoolSubmission(atom);
@@ -66,7 +66,7 @@ public class SharedMempool implements Mempool {
 	}
 
 	@Override
-	public List<SimpleRadixEngineAtom> getAtoms(int count, Set<AID> seen) {
+	public List<LedgerAtom> getAtoms(int count, Set<AID> seen) {
 		return this.localMempool.getAtoms(count, seen);
 	}
 

--- a/radixdlt/src/main/java/com/radixdlt/mempool/SharedMempool.java
+++ b/radixdlt/src/main/java/com/radixdlt/mempool/SharedMempool.java
@@ -17,6 +17,7 @@
 
 package com.radixdlt.mempool;
 
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -24,7 +25,6 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import com.radixdlt.identifiers.AID;
-import com.radixdlt.atommodel.Atom;
 import com.radixdlt.counters.SystemCounters;
 import com.radixdlt.counters.SystemCounters.CounterType;
 
@@ -47,7 +47,7 @@ public class SharedMempool implements Mempool {
 	}
 
 	@Override
-	public void addAtom(Atom atom) throws MempoolFullException, MempoolDuplicateException {
+	public void addAtom(SimpleRadixEngineAtom atom) throws MempoolFullException, MempoolDuplicateException {
 		this.localMempool.addAtom(atom);
 		updateCounts();
 		this.networkSender.sendMempoolSubmission(atom);
@@ -66,7 +66,7 @@ public class SharedMempool implements Mempool {
 	}
 
 	@Override
-	public List<Atom> getAtoms(int count, Set<AID> seen) {
+	public List<SimpleRadixEngineAtom> getAtoms(int count, Set<AID> seen) {
 		return this.localMempool.getAtoms(count, seen);
 	}
 

--- a/radixdlt/src/main/java/com/radixdlt/mempool/SubmissionControl.java
+++ b/radixdlt/src/main/java/com/radixdlt/mempool/SubmissionControl.java
@@ -21,8 +21,6 @@ import java.util.function.Consumer;
 
 import org.json.JSONObject;
 
-import com.radixdlt.identifiers.AID;
-
 /**
  * Handle atom submission.
  */
@@ -41,10 +39,9 @@ public interface SubmissionControl {
 	 *
 	 * @param atomJson the {@link JSONObject} to deserialise for the atom
 	 * @param deserialisationCallback the callback to call after deserialisation has occurred
-	 * @return The {@link AID} of the submitted atom
 	 * @throws MempoolFullException if the underlying mempool is too full to accept new submissions
 	 * @throws MempoolDuplicateException if the underlying mempool already has the specified atom
 	 */
-	AID submitAtom(JSONObject atomJson, Consumer<LedgerAtom> deserialisationCallback)
+	void submitAtom(JSONObject atomJson, Consumer<LedgerAtom> deserialisationCallback)
 		throws MempoolFullException, MempoolDuplicateException;
 }

--- a/radixdlt/src/main/java/com/radixdlt/mempool/SubmissionControl.java
+++ b/radixdlt/src/main/java/com/radixdlt/mempool/SubmissionControl.java
@@ -16,25 +16,25 @@
  */
 package com.radixdlt.mempool;
 
+import com.radixdlt.middleware2.LedgerAtom;
 import java.util.function.Consumer;
 
 import org.json.JSONObject;
 
 import com.radixdlt.identifiers.AID;
-import com.radixdlt.atommodel.Atom;
 
 /**
  * Handle atom submission.
  */
 public interface SubmissionControl {
 	/**
-	 * Handle atom submission from API or network as an {@link Atom}.
+	 * Handle atom submission from API or network as an {@link LedgerAtom}.
 	 *
-	 * @param atom the {@link Atom} for the atom
+	 * @param atom the {@link LedgerAtom} for the atom
 	 * @throws MempoolFullException if the underlying mempool is too full to accept new submissions
 	 * @throws MempoolDuplicateException if the underlying mempool already has the specified atom
 	 */
-	void submitAtom(Atom atom) throws MempoolFullException, MempoolDuplicateException;
+	void submitAtom(LedgerAtom atom) throws MempoolFullException, MempoolDuplicateException;
 
 	/**
 	 * Handle atom submission from API or network as an {@link JSONObject}.
@@ -45,6 +45,6 @@ public interface SubmissionControl {
 	 * @throws MempoolFullException if the underlying mempool is too full to accept new submissions
 	 * @throws MempoolDuplicateException if the underlying mempool already has the specified atom
 	 */
-	AID submitAtom(JSONObject atomJson, Consumer<Atom> deserialisationCallback)
+	AID submitAtom(JSONObject atomJson, Consumer<LedgerAtom> deserialisationCallback)
 		throws MempoolFullException, MempoolDuplicateException;
 }

--- a/radixdlt/src/main/java/com/radixdlt/mempool/SubmissionControlImpl.java
+++ b/radixdlt/src/main/java/com/radixdlt/mempool/SubmissionControlImpl.java
@@ -81,7 +81,7 @@ class SubmissionControlImpl implements SubmissionControl {
 
 		if (validationError.isPresent()) {
 			CMError error = validationError.get();
-			ConstraintMachineValidationException ex = new ConstraintMachineValidationException(atom, error.getErrMsg(), error.getDataPointer());
+			ConstraintMachineValidationException ex = new ConstraintMachineValidationException(reAtom, error.getErrMsg(), error.getDataPointer());
 			log.info(
 				"Rejecting atom {} with constraint machine error '{}' at '{}'.",
 				atom.getAID(),

--- a/radixdlt/src/main/java/com/radixdlt/mempool/SubmissionControlImpl.java
+++ b/radixdlt/src/main/java/com/radixdlt/mempool/SubmissionControlImpl.java
@@ -32,7 +32,6 @@ import org.json.JSONObject;
 import org.radix.atoms.events.AtomExceptionEvent;
 import org.radix.events.Events;
 
-import com.radixdlt.identifiers.AID;
 import com.radixdlt.atommodel.Atom;
 import com.radixdlt.engine.RadixEngine;
 import com.radixdlt.serialization.Serialization;
@@ -80,7 +79,7 @@ class SubmissionControlImpl implements SubmissionControl {
 	}
 
 	@Override
-	public AID submitAtom(JSONObject atomJson, Consumer<LedgerAtom> deserialisationCallback) throws MempoolFullException, MempoolDuplicateException {
+	public void submitAtom(JSONObject atomJson, Consumer<LedgerAtom> deserialisationCallback) throws MempoolFullException, MempoolDuplicateException {
 		final Atom rawAtom = this.serialization.fromJsonObject(atomJson, Atom.class);
 		final LedgerAtom atom;
 		try {
@@ -91,12 +90,11 @@ class SubmissionControlImpl implements SubmissionControl {
 				rawAtom.getAID()
 			);
 			this.events.broadcast(new AtomExceptionEvent(e, rawAtom.getAID()));
-			return rawAtom.getAID();
+			return;
 		}
 
 		deserialisationCallback.accept(atom);
 		submitAtom(atom);
-		return atom.getAID();
 	}
 
 	@Override

--- a/radixdlt/src/main/java/com/radixdlt/mempool/SubmissionControlImpl.java
+++ b/radixdlt/src/main/java/com/radixdlt/mempool/SubmissionControlImpl.java
@@ -17,9 +17,9 @@
 
 package com.radixdlt.mempool;
 
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
 import com.radixdlt.middleware2.converters.AtomConversionException;
-import com.radixdlt.middleware2.converters.AtomToRadixEngineAtomConverter;
+import com.radixdlt.middleware2.converters.AtomToLedgerAtomConverter;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -43,18 +43,18 @@ class SubmissionControlImpl implements SubmissionControl {
 	private static final Logger log = LogManager.getLogger("submission");
 
 	private final Mempool mempool;
-	private final RadixEngine<SimpleRadixEngineAtom> radixEngine;
+	private final RadixEngine<LedgerAtom> radixEngine;
 	private final Serialization serialization;
 	private final Events events;
-	private final AtomToRadixEngineAtomConverter converter;
+	private final AtomToLedgerAtomConverter converter;
 
 	@Inject
 	SubmissionControlImpl(
 		Mempool mempool,
-		RadixEngine<SimpleRadixEngineAtom> radixEngine,
+		RadixEngine<LedgerAtom> radixEngine,
 		Serialization serialization,
 		Events events,
-		AtomToRadixEngineAtomConverter converter
+		AtomToLedgerAtomConverter converter
 	) {
 		this.mempool = Objects.requireNonNull(mempool);
 		this.radixEngine = Objects.requireNonNull(radixEngine);
@@ -65,7 +65,7 @@ class SubmissionControlImpl implements SubmissionControl {
 
 	@Override
 	public void submitAtom(Atom atom) throws MempoolFullException, MempoolDuplicateException {
-		final SimpleRadixEngineAtom reAtom;
+		final LedgerAtom reAtom;
 		try {
 			reAtom = converter.convert(atom);
 		} catch (AtomConversionException e) {

--- a/radixdlt/src/main/java/com/radixdlt/mempool/SubmissionControlImpl.java
+++ b/radixdlt/src/main/java/com/radixdlt/mempool/SubmissionControlImpl.java
@@ -69,6 +69,10 @@ class SubmissionControlImpl implements SubmissionControl {
 		try {
 			reAtom = converter.convert(atom);
 		} catch (AtomConversionException e) {
+			log.info(
+				"Rejecting atom {} due to conversion issues.",
+				atom.getAID()
+			);
 			this.events.broadcast(new AtomExceptionEvent(e, atom.getAID()));
 			return;
 		}

--- a/radixdlt/src/main/java/com/radixdlt/mempool/messages/MempoolAtomAddedMessage.java
+++ b/radixdlt/src/main/java/com/radixdlt/mempool/messages/MempoolAtomAddedMessage.java
@@ -17,12 +17,12 @@
 
 package com.radixdlt.mempool.messages;
 
+import com.radixdlt.middleware2.LedgerAtom;
 import java.util.Objects;
 
 import org.radix.network.messaging.Message;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.radixdlt.atommodel.Atom;
 import com.radixdlt.serialization.DsonOutput;
 import com.radixdlt.serialization.DsonOutput.Output;
 import com.radixdlt.serialization.SerializerId2;
@@ -31,7 +31,7 @@ import com.radixdlt.serialization.SerializerId2;
 public class MempoolAtomAddedMessage extends Message {
 	@JsonProperty("atom")
 	@DsonOutput(Output.ALL)
-	private final Atom atom;
+	private final LedgerAtom atom;
 
 	MempoolAtomAddedMessage() {
 		// Serializer only
@@ -39,12 +39,12 @@ public class MempoolAtomAddedMessage extends Message {
 		this.atom = null;
 	}
 
-	public MempoolAtomAddedMessage(int magic, Atom vertex) {
+	public MempoolAtomAddedMessage(int magic, LedgerAtom vertex) {
 		super(magic);
 		this.atom = Objects.requireNonNull(vertex);
 	}
 
-	public Atom atom() {
+	public LedgerAtom atom() {
 		return this.atom;
 	}
 

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/AtomCheckHook.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/AtomCheckHook.java
@@ -72,7 +72,7 @@ public class AtomCheckHook implements CMSuccessHook<LedgerAtom> {
 					return Result.error("atom fee invalid, metadata contains invalid powNonce: " + powNonceString);
 				}
 
-				final Hash powFeeHash = atom.getRaw().copyExcludingMetadata(Atom.METADATA_POW_NONCE_KEY).getHash();
+				final Hash powFeeHash = atom.getPowFeeHash();
 				POW pow = new POW(universeSupplier.get().getMagic(), powFeeHash, powNonce);
 				Result powResult = checkPow(pow, powFeeHash, DEFAULT_TARGET, universeSupplier.get().getMagic());
 				if (powResult.isError()) {

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/AtomCheckHook.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/AtomCheckHook.java
@@ -1,0 +1,120 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package com.radixdlt.middleware2;
+
+import com.radixdlt.atomos.Result;
+import com.radixdlt.atommodel.Atom;
+import com.radixdlt.crypto.Hash;
+import com.radixdlt.engine.CMSuccessHook;
+import com.radixdlt.universe.Universe;
+import com.radixdlt.utils.POW;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+
+public class AtomCheckHook implements CMSuccessHook<LedgerAtom> {
+	private final boolean skipAtomFeeCheck;
+	private final Supplier<Universe> universeSupplier;
+	private final LongSupplier timestampSupplier;
+	private static final Hash DEFAULT_TARGET = new Hash("0000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+	private final int maximumDrift;
+
+	public AtomCheckHook(
+		Supplier<Universe> universeSupplier,
+		LongSupplier timestampSupplier,
+		boolean skipAtomFeeCheck,
+		int maximumDrift
+	) {
+		this.universeSupplier = universeSupplier;
+		this.timestampSupplier = timestampSupplier;
+		this.skipAtomFeeCheck = skipAtomFeeCheck;
+		this.maximumDrift = maximumDrift;
+	}
+
+	@Override
+	public Result hook(LedgerAtom atom) {
+		if (atom.getCMInstruction().getMicroInstructions().isEmpty()) {
+			return Result.error("atom has no instructions");
+		}
+
+		final boolean isMagic = Objects.equals(atom.getMetaData().get("magic"), "0xdeadbeef");
+
+		// Atom has fee
+		if (!skipAtomFeeCheck) {
+			if (universeSupplier.get().getGenesis().stream().map(Atom::getAID).noneMatch(atom.getAID()::equals)
+				&& !isMagic) {
+
+				String powNonceString = atom.getMetaData().get(Atom.METADATA_POW_NONCE_KEY);
+				if (powNonceString == null) {
+					return Result.error("atom fee missing, metadata does not contain '" + Atom.METADATA_POW_NONCE_KEY + "'");
+				}
+
+				final long powNonce;
+				try {
+					powNonce = Long.parseLong(powNonceString);
+				} catch (NumberFormatException e) {
+					return Result.error("atom fee invalid, metadata contains invalid powNonce: " + powNonceString);
+				}
+
+				final Hash powFeeHash = atom.getRaw().copyExcludingMetadata(Atom.METADATA_POW_NONCE_KEY).getHash();
+				POW pow = new POW(universeSupplier.get().getMagic(), powFeeHash, powNonce);
+				Result powResult = checkPow(pow, powFeeHash, DEFAULT_TARGET, universeSupplier.get().getMagic());
+				if (powResult.isError()) {
+					return powResult;
+				}
+			}
+		}
+
+		String timestampString = atom.getMetaData().get(Atom.METADATA_TIMESTAMP_KEY);
+		if (timestampString == null) {
+			return Result.error("atom metadata does not contain '" + Atom.METADATA_TIMESTAMP_KEY + "'");
+		}
+		try {
+			long timestamp = Long.parseLong(timestampString);
+
+			if (timestamp > timestampSupplier.getAsLong()
+				+ TimeUnit.MILLISECONDS.convert(maximumDrift, TimeUnit.SECONDS)) {
+				return Result.error("atom metadata timestamp is after allowed drift time");
+			}
+			if (timestamp < universeSupplier.get().getTimestamp()) {
+				return Result.error("atom metadata timestamp is before universe creation");
+			}
+		} catch (NumberFormatException e) {
+			return Result.error("atom metadata contains invalid timestamp: " + timestampString);
+		}
+
+		return Result.success();
+	}
+
+	private static Result checkPow(POW pow, Hash hash, Hash target, int universeMagic) {
+		if (!pow.getSeed().equals(hash)) {
+			return Result.error("atom fee invalid: seed does not match validation parameter seed (" + pow.getSeed() + ") + hash(" + hash + ")");
+		}
+
+		if (pow.getMagic() != universeMagic) {
+			return Result.error("atom fee invalid: magic '" + pow.getMagic() + "' does not match Universe magic '");
+		}
+
+		if (pow.getHash().compareTo(target) >= 0) {
+			return Result.error("atom fee invalid: '" + pow.getHash() + "' does not meet target '" + target + "'");
+		}
+
+		return Result.success();
+	}
+}

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/LedgerAtom.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/LedgerAtom.java
@@ -1,0 +1,153 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package com.radixdlt.middleware2;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+import com.google.common.collect.ImmutableMap;
+import com.radixdlt.DefaultSerialization;
+import com.radixdlt.atommodel.Atom;
+import com.radixdlt.constraintmachine.CMInstruction;
+import com.radixdlt.constraintmachine.CMMicroInstruction;
+import com.radixdlt.constraintmachine.DataPointer;
+import com.radixdlt.constraintmachine.Particle;
+import com.radixdlt.constraintmachine.Spin;
+import com.radixdlt.engine.RadixEngineAtom;
+import com.radixdlt.identifiers.AID;
+import com.radixdlt.middleware.ParticleGroup;
+import com.radixdlt.middleware.SpunParticle;
+import com.radixdlt.serialization.DsonOutput.Output;
+import com.radixdlt.serialization.SerializationException;
+import com.radixdlt.store.SpinStateMachine;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+
+public final class LedgerAtom implements RadixEngineAtom {
+	private static final int MAX_ATOM_SIZE = 1024 * 1024;
+	private final transient CMInstruction cmInstruction;
+	private final transient ImmutableMap<String, String> metaData;
+	private final Atom atom;
+
+	private LedgerAtom(Atom atom, CMInstruction cmInstruction) {
+		this.atom = Objects.requireNonNull(atom);
+		this.cmInstruction = Objects.requireNonNull(cmInstruction);
+		this.metaData = ImmutableMap.copyOf(atom.getMetaData());
+	}
+
+	@Override
+	public CMInstruction getCMInstruction() {
+		return cmInstruction;
+	}
+
+	@Override
+	public AID getAID() {
+		return atom.getAID();
+	}
+
+	public ImmutableMap<String, String> getMetaData() {
+		return metaData;
+	}
+
+	public Atom getRaw() {
+		return atom;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(atom);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (!(o instanceof LedgerAtom)) {
+			return false;
+		}
+
+		LedgerAtom other = (LedgerAtom) o;
+		return Objects.equals(other.atom, this.atom);
+	}
+
+	public static class CMAtomConversionException extends Exception {
+		private final DataPointer dataPointer;
+		CMAtomConversionException(DataPointer dataPointer, String error) {
+			super(error);
+			this.dataPointer = dataPointer;
+		}
+
+		public DataPointer getDataPointer() {
+			return dataPointer;
+		}
+	}
+
+	static ImmutableList<CMMicroInstruction> toCMMicroInstructions(List<ParticleGroup> particleGroups) throws CMAtomConversionException {
+		final HashMap<Particle, Spin> spins = new HashMap<>();
+		final ImmutableList.Builder<CMMicroInstruction> microInstructionsBuilder = new Builder<>();
+		for (int i = 0; i < particleGroups.size(); i++) {
+			ParticleGroup pg = particleGroups.get(i);
+			final HashSet<Particle> seen = new HashSet<>();
+			for (int j = 0; j < pg.getParticleCount(); j++) {
+				SpunParticle sp = pg.getSpunParticle(j);
+				Particle particle = sp.getParticle();
+
+				if (seen.contains(particle)) {
+					throw new CMAtomConversionException(DataPointer.ofParticle(i, j), "Particle transition must be unique in group");
+				}
+				seen.add(particle);
+
+				Spin currentSpin = spins.get(particle);
+				if (currentSpin == null) {
+					Spin checkSpin = SpinStateMachine.prev(sp.getSpin());
+					microInstructionsBuilder.add(CMMicroInstruction.checkSpin(particle, checkSpin));
+				} else {
+					if (!SpinStateMachine.canTransition(currentSpin, sp.getSpin())) {
+						throw new CMAtomConversionException(DataPointer.ofParticle(i, j), "Invalid internal spin");
+					}
+				}
+
+				spins.put(particle, sp.getSpin());
+				microInstructionsBuilder.add(CMMicroInstruction.push(particle));
+			}
+			microInstructionsBuilder.add(CMMicroInstruction.particleGroup());
+		}
+
+		return microInstructionsBuilder.build();
+	}
+
+	public static LedgerAtom convert(Atom atom) throws CMAtomConversionException {
+		final int computedSize;
+		try {
+			computedSize = DefaultSerialization.getInstance().toDson(atom, Output.PERSIST).length;
+		} catch (SerializationException e) {
+			throw new IllegalStateException("Could not compute size", e);
+		}
+		if (computedSize > MAX_ATOM_SIZE) {
+			throw new CMAtomConversionException(DataPointer.ofAtom(), "Atom too big");
+		}
+
+		final ImmutableList<CMMicroInstruction> microInstructions = toCMMicroInstructions(atom.getParticleGroups());
+		final CMInstruction cmInstruction = new CMInstruction(
+			microInstructions,
+			atom.getHash(),
+			ImmutableMap.copyOf(atom.getSignatures())
+		);
+
+		return new LedgerAtom(atom, cmInstruction);
+	}
+}

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/LedgerAtom.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/LedgerAtom.java
@@ -47,6 +47,10 @@ import java.util.List;
 import java.util.Objects;
 import javax.annotation.concurrent.Immutable;
 
+/**
+ * An atom which can be processed by the radix engine and to be stored on
+ * ledger.
+ */
 @Immutable
 @SerializerId2("consensus.ledger_atom")
 public final class LedgerAtom implements RadixEngineAtom {
@@ -113,10 +117,6 @@ public final class LedgerAtom implements RadixEngineAtom {
 
 	public ImmutableMap<String, String> getMetaData() {
 		return metaData;
-	}
-
-	public byte[] getRaw() {
-		return rawAtom;
 	}
 
 	public Hash getPowFeeHash() {
@@ -193,7 +193,27 @@ public final class LedgerAtom implements RadixEngineAtom {
 		);
 	}
 
-	public static LedgerAtom convert(Atom atom) throws LedgerAtomConversionException {
+	/**
+	 * Converts a ledger atom back to an api atom (to be deprecated)
+	 * @param atom the ledger atom to convert
+	 * @return an api atom
+	 */
+	public static Atom convertToApiAtom(LedgerAtom atom) {
+		try {
+			return DefaultSerialization.getInstance().fromDson(atom.rawAtom, Atom.class);
+		} catch (SerializationException e) {
+			throw new IllegalStateException("Could not convert back to api atom " + atom);
+		}
+	}
+
+	/**
+	 * Convert an api atom (to be deprecated) into a ledger atom.
+	 *
+	 * @param atom the atom to convert
+	 * @return an atom to be stored on ledger
+	 * @throws LedgerAtomConversionException on conversion errors
+	 */
+	public static LedgerAtom convertFromApiAtom(Atom atom) throws LedgerAtomConversionException {
 		final byte[] rawAtom;
 		try {
 			rawAtom = DefaultSerialization.getInstance().toDson(atom, Output.PERSIST);

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/LedgerAtomChecker.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/LedgerAtomChecker.java
@@ -27,6 +27,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
+/**
+ * Checks that metadata in the ledger atom is well formed and follows what is
+ * needed for both consensus and governance.
+ */
 public class LedgerAtomChecker implements CMSuccessHook<LedgerAtom> {
 	private final boolean skipAtomFeeCheck;
 	private final Supplier<Universe> universeSupplier;

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/LedgerAtomChecker.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/LedgerAtomChecker.java
@@ -28,14 +28,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
-public class AtomCheckHook implements CMSuccessHook<LedgerAtom> {
+public class LedgerAtomChecker implements CMSuccessHook<LedgerAtom> {
 	private final boolean skipAtomFeeCheck;
 	private final Supplier<Universe> universeSupplier;
 	private final LongSupplier timestampSupplier;
 	private static final Hash DEFAULT_TARGET = new Hash("0000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
 	private final int maximumDrift;
 
-	public AtomCheckHook(
+	public LedgerAtomChecker(
 		Supplier<Universe> universeSupplier,
 		LongSupplier timestampSupplier,
 		boolean skipAtomFeeCheck,

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/MiddlewareModule.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/MiddlewareModule.java
@@ -30,8 +30,6 @@ import com.radixdlt.atomos.CMAtomOS;
 import com.radixdlt.atomos.Result;
 import com.radixdlt.constraintmachine.ConstraintMachine;
 import com.radixdlt.engine.RadixEngine;
-import com.radixdlt.middleware.AtomCheckHook;
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
 import com.radixdlt.middleware2.converters.AtomToBinaryConverter;
 import com.radixdlt.middleware2.processing.EngineAtomEventListener;
 import com.radixdlt.middleware2.store.LedgerEngineStore;
@@ -78,15 +76,15 @@ public class MiddlewareModule extends AbstractModule {
 
 	@Provides
 	@Singleton
-	private RadixEngine<SimpleRadixEngineAtom> getRadixEngine(
+	private RadixEngine<LedgerAtom> getRadixEngine(
 			ConstraintMachine constraintMachine,
 			UnaryOperator<CMStore> virtualStoreLayer,
-			EngineStore<SimpleRadixEngineAtom> engineStore,
+			EngineStore<LedgerAtom> engineStore,
 			Serialization serialization,
 			RuntimeProperties properties,
 			Universe universe
 	) {
-		RadixEngine<SimpleRadixEngineAtom> radixEngine = new RadixEngine<SimpleRadixEngineAtom>(
+		RadixEngine<LedgerAtom> radixEngine = new RadixEngine<>(
 			constraintMachine,
 			virtualStoreLayer,
 			engineStore
@@ -95,12 +93,12 @@ public class MiddlewareModule extends AbstractModule {
 		final boolean skipAtomFeeCheck = properties.get("debug.nopow", false);
 
 		radixEngine.addCMSuccessHook(
-				new AtomCheckHook(
-						() -> universe,
-						Time::currentTimestamp,
-						skipAtomFeeCheck,
-						Time.MAXIMUM_DRIFT
-				)
+			new AtomCheckHook(
+				() -> universe,
+				Time::currentTimestamp,
+				skipAtomFeeCheck,
+				Time.MAXIMUM_DRIFT
+			)
 		);
 
 		radixEngine.addAtomEventListener(new EngineAtomEventListener(serialization));
@@ -110,7 +108,7 @@ public class MiddlewareModule extends AbstractModule {
 
 	@Override
 	protected void configure() {
-		bind(new TypeLiteral<EngineStore<SimpleRadixEngineAtom>>() { }).to(LedgerEngineStore.class).in(Scopes.SINGLETON);
+		bind(new TypeLiteral<EngineStore<LedgerAtom>>() { }).to(LedgerEngineStore.class).in(Scopes.SINGLETON);
 		bind(AtomToBinaryConverter.class).toInstance(new AtomToBinaryConverter(DefaultSerialization.getInstance()));
 	}
 }

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/MiddlewareModule.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/MiddlewareModule.java
@@ -93,7 +93,7 @@ public class MiddlewareModule extends AbstractModule {
 		final boolean skipAtomFeeCheck = properties.get("debug.nopow", false);
 
 		radixEngine.addCMSuccessHook(
-			new AtomCheckHook(
+			new LedgerAtomChecker(
 				() -> universe,
 				Time::currentTimestamp,
 				skipAtomFeeCheck,

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/MiddlewareModule.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/MiddlewareModule.java
@@ -21,6 +21,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
+import com.google.inject.TypeLiteral;
 import com.radixdlt.DefaultSerialization;
 import com.radixdlt.atommodel.message.MessageParticleConstraintScrypt;
 import com.radixdlt.atommodel.tokens.TokensConstraintScrypt;
@@ -30,6 +31,7 @@ import com.radixdlt.atomos.Result;
 import com.radixdlt.constraintmachine.ConstraintMachine;
 import com.radixdlt.engine.RadixEngine;
 import com.radixdlt.middleware.AtomCheckHook;
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 import com.radixdlt.middleware2.converters.AtomToBinaryConverter;
 import com.radixdlt.middleware2.processing.EngineAtomEventListener;
 import com.radixdlt.middleware2.store.LedgerEngineStore;
@@ -63,9 +65,9 @@ public class MiddlewareModule extends AbstractModule {
 	@Singleton
 	private ConstraintMachine buildConstraintMachine(CMAtomOS os) {
 		final ConstraintMachine constraintMachine = new ConstraintMachine.Builder()
-				.setParticleTransitionProcedures(os.buildTransitionProcedures())
-				.setParticleStaticCheck(os.buildParticleStaticCheck())
-				.build();
+			.setParticleTransitionProcedures(os.buildTransitionProcedures())
+			.setParticleStaticCheck(os.buildParticleStaticCheck())
+			.build();
 		return constraintMachine;
 	}
 
@@ -76,15 +78,15 @@ public class MiddlewareModule extends AbstractModule {
 
 	@Provides
 	@Singleton
-	private RadixEngine getRadixEngine(
+	private RadixEngine<SimpleRadixEngineAtom> getRadixEngine(
 			ConstraintMachine constraintMachine,
 			UnaryOperator<CMStore> virtualStoreLayer,
-			EngineStore engineStore,
+			EngineStore<SimpleRadixEngineAtom> engineStore,
 			Serialization serialization,
 			RuntimeProperties properties,
 			Universe universe
 	) {
-		RadixEngine radixEngine = new RadixEngine(
+		RadixEngine<SimpleRadixEngineAtom> radixEngine = new RadixEngine<SimpleRadixEngineAtom>(
 			constraintMachine,
 			virtualStoreLayer,
 			engineStore
@@ -108,7 +110,7 @@ public class MiddlewareModule extends AbstractModule {
 
 	@Override
 	protected void configure() {
-		bind(EngineStore.class).to(LedgerEngineStore.class).in(Scopes.SINGLETON);
+		bind(new TypeLiteral<EngineStore<SimpleRadixEngineAtom>>() { }).to(LedgerEngineStore.class).in(Scopes.SINGLETON);
 		bind(AtomToBinaryConverter.class).toInstance(new AtomToBinaryConverter(DefaultSerialization.getInstance()));
 	}
 }

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/MiddlewareModule.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/MiddlewareModule.java
@@ -29,6 +29,7 @@ import com.radixdlt.atommodel.unique.UniqueParticleConstraintScrypt;
 import com.radixdlt.atomos.CMAtomOS;
 import com.radixdlt.atomos.Result;
 import com.radixdlt.constraintmachine.ConstraintMachine;
+import com.radixdlt.crypto.Hash;
 import com.radixdlt.engine.RadixEngine;
 import com.radixdlt.middleware2.converters.AtomToBinaryConverter;
 import com.radixdlt.middleware2.processing.EngineAtomEventListener;
@@ -43,6 +44,8 @@ import org.radix.time.Time;
 import java.util.function.UnaryOperator;
 
 public class MiddlewareModule extends AbstractModule {
+	private static final Hash DEFAULT_FEE_TARGET = new Hash("0000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+
 	@Provides
 	@Singleton
 	private CMAtomOS buildCMAtomOS(Universe universe) {
@@ -62,11 +65,10 @@ public class MiddlewareModule extends AbstractModule {
 	@Provides
 	@Singleton
 	private ConstraintMachine buildConstraintMachine(CMAtomOS os) {
-		final ConstraintMachine constraintMachine = new ConstraintMachine.Builder()
+		return new ConstraintMachine.Builder()
 			.setParticleTransitionProcedures(os.buildTransitionProcedures())
 			.setParticleStaticCheck(os.buildParticleStaticCheck())
 			.build();
-		return constraintMachine;
 	}
 
 	@Provides
@@ -84,23 +86,24 @@ public class MiddlewareModule extends AbstractModule {
 			RuntimeProperties properties,
 			Universe universe
 	) {
+		final boolean skipAtomFeeCheck = properties.get("debug.nopow", false);
+		final PowFeeComputer powFeeComputer = new PowFeeComputer(() -> universe);
+		final LedgerAtomChecker ledgerAtomChecker =
+			new LedgerAtomChecker(
+				() -> universe,
+				Time::currentTimestamp,
+				powFeeComputer,
+				DEFAULT_FEE_TARGET,
+				skipAtomFeeCheck,
+				Time.MAXIMUM_DRIFT
+			);
+
 		RadixEngine<LedgerAtom> radixEngine = new RadixEngine<>(
 			constraintMachine,
 			virtualStoreLayer,
 			engineStore
 		);
-
-		final boolean skipAtomFeeCheck = properties.get("debug.nopow", false);
-
-		radixEngine.addCMSuccessHook(
-			new LedgerAtomChecker(
-				() -> universe,
-				Time::currentTimestamp,
-				skipAtomFeeCheck,
-				Time.MAXIMUM_DRIFT
-			)
-		);
-
+		radixEngine.addCMSuccessHook(ledgerAtomChecker);
 		radixEngine.addAtomEventListener(new EngineAtomEventListener(serialization));
 
 		return radixEngine;

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/MiddlewareModule.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/MiddlewareModule.java
@@ -79,12 +79,12 @@ public class MiddlewareModule extends AbstractModule {
 	@Provides
 	@Singleton
 	private RadixEngine<LedgerAtom> getRadixEngine(
-			ConstraintMachine constraintMachine,
-			UnaryOperator<CMStore> virtualStoreLayer,
-			EngineStore<LedgerAtom> engineStore,
-			Serialization serialization,
-			RuntimeProperties properties,
-			Universe universe
+		ConstraintMachine constraintMachine,
+		UnaryOperator<CMStore> virtualStoreLayer,
+		EngineStore<LedgerAtom> engineStore,
+		Serialization serialization,
+		RuntimeProperties properties,
+		Universe universe
 	) {
 		final boolean skipAtomFeeCheck = properties.get("debug.nopow", false);
 		final PowFeeComputer powFeeComputer = new PowFeeComputer(() -> universe);

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/PowFeeComputer.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/PowFeeComputer.java
@@ -23,7 +23,7 @@ import com.radixdlt.utils.POW;
 import java.util.function.Supplier;
 
 /**
- * Temporary class for computing pow spent in an atom
+ * Temporary (will be removing pow fees soon) class for computing pow spent in an atom
  */
 public final class PowFeeComputer {
 	private final Supplier<Universe> universeSupplier;

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/PowFeeComputer.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/PowFeeComputer.java
@@ -1,0 +1,41 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package com.radixdlt.middleware2;
+
+import com.radixdlt.crypto.Hash;
+import com.radixdlt.universe.Universe;
+import com.radixdlt.utils.POW;
+import java.util.function.Supplier;
+
+/**
+ * Temporary class for computing pow spent in an atom
+ */
+public final class PowFeeComputer {
+	private final Supplier<Universe> universeSupplier;
+	public PowFeeComputer(
+		Supplier<Universe> universeSupplier
+	) {
+		this.universeSupplier = universeSupplier;
+	}
+
+	public Hash computePowSpent(LedgerAtom ledgerAtom, long powNonce) {
+		final Hash powFeeHash = ledgerAtom.getPowFeeHash();
+		POW pow = new POW(universeSupplier.get().getMagic(), powFeeHash, powNonce);
+		return pow.getHash();
+	}
+}

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/converters/AtomConversionException.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/converters/AtomConversionException.java
@@ -17,8 +17,18 @@
 
 package com.radixdlt.middleware2.converters;
 
-public class AtomConversionException extends Exception {
-	public AtomConversionException(Exception cause) {
+import com.radixdlt.constraintmachine.DataPointer;
+import java.util.Objects;
+
+public final class AtomConversionException extends Exception {
+	private final DataPointer dataPointer;
+
+	public AtomConversionException(DataPointer dataPointer, Exception cause) {
 		super(cause);
+		this.dataPointer = Objects.requireNonNull(dataPointer);
+	}
+
+	public String getPointerToIssue() {
+		return dataPointer.toString();
 	}
 }

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/converters/AtomConversionException.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/converters/AtomConversionException.java
@@ -6,7 +6,7 @@
  * compliance with the License.  You may obtain a copy of the
  * License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -15,16 +15,10 @@
  * language governing permissions and limitations under the License.
  */
 
-package com.radixdlt.mempool;
+package com.radixdlt.middleware2.converters;
 
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
-
-/**
- * Exception thrown when an attempt to add new items would
- * exceed the mempool's maximum capacity.
- */
-public class MempoolDuplicateException extends MempoolRejectedException {
-	public MempoolDuplicateException(SimpleRadixEngineAtom atom, String message) {
-		super(atom, message);
+public class AtomConversionException extends Exception {
+	public AtomConversionException(Exception cause) {
+		super(cause);
 	}
 }

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/converters/AtomConversionException.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/converters/AtomConversionException.java
@@ -20,6 +20,10 @@ package com.radixdlt.middleware2.converters;
 import com.radixdlt.constraintmachine.DataPointer;
 import java.util.Objects;
 
+/**
+ * Exception thrown when converting from the raw api Atom to
+ * a RadixEngine atom
+ */
 public final class AtomConversionException extends Exception {
 	private final DataPointer dataPointer;
 

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/converters/AtomToBinaryConverter.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/converters/AtomToBinaryConverter.java
@@ -18,9 +18,8 @@
 package com.radixdlt.middleware2.converters;
 
 import com.radixdlt.atommodel.Atom;
-import com.radixdlt.middleware.RadixEngineUtils;
-import com.radixdlt.middleware.RadixEngineUtils.CMAtomConversionException;
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
+import com.radixdlt.middleware2.LedgerAtom.CMAtomConversionException;
 import com.radixdlt.serialization.DsonOutput;
 import com.radixdlt.serialization.Serialization;
 import com.radixdlt.serialization.SerializationException;
@@ -32,18 +31,18 @@ public final class AtomToBinaryConverter {
 		this.serializer = serializer;
 	}
 
-	public byte[] toLedgerEntryContent(SimpleRadixEngineAtom reAtom) {
+	public byte[] toLedgerEntryContent(LedgerAtom reAtom) {
 		try {
-			return serializer.toDson(reAtom.getAtom(), DsonOutput.Output.PERSIST);
+			return serializer.toDson(reAtom.getRaw(), DsonOutput.Output.PERSIST);
 		} catch (SerializationException e) {
 			throw new RuntimeException(String.format("Serialization for Atom with ID: %s failed", reAtom.getAID()));
 		}
 	}
 
-	public SimpleRadixEngineAtom toAtom(byte[] ledgerEntryContent) {
+	public LedgerAtom toAtom(byte[] ledgerEntryContent) {
 		try {
 			Atom rawAtom =  serializer.fromDson(ledgerEntryContent, Atom.class);
-			return RadixEngineUtils.toCMAtom(rawAtom);
+			return LedgerAtom.convert(rawAtom);
 		} catch (SerializationException | CMAtomConversionException e) {
 			throw new RuntimeException("Deserialization of Atom failed");
 		}

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/converters/AtomToBinaryConverter.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/converters/AtomToBinaryConverter.java
@@ -41,7 +41,7 @@ public final class AtomToBinaryConverter {
 		try {
 			return serializer.fromDson(ledgerEntryContent, LedgerAtom.class);
 		} catch (SerializationException e) {
-			throw new RuntimeException("Deserialization of Atom failed", e);
+			throw new IllegalStateException("Deserialization of Atom failed", e);
 		}
 	}
 }

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/converters/AtomToBinaryConverter.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/converters/AtomToBinaryConverter.java
@@ -18,6 +18,9 @@
 package com.radixdlt.middleware2.converters;
 
 import com.radixdlt.atommodel.Atom;
+import com.radixdlt.middleware.RadixEngineUtils;
+import com.radixdlt.middleware.RadixEngineUtils.CMAtomConversionException;
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 import com.radixdlt.serialization.DsonOutput;
 import com.radixdlt.serialization.Serialization;
 import com.radixdlt.serialization.SerializationException;
@@ -29,18 +32,19 @@ public final class AtomToBinaryConverter {
 		this.serializer = serializer;
 	}
 
-	public byte[] toLedgerEntryContent(Atom atom) {
+	public byte[] toLedgerEntryContent(SimpleRadixEngineAtom reAtom) {
 		try {
-			return serializer.toDson(atom, DsonOutput.Output.PERSIST);
+			return serializer.toDson(reAtom.getAtom(), DsonOutput.Output.PERSIST);
 		} catch (SerializationException e) {
-			throw new RuntimeException(String.format("Serialization for Atom with ID: %s failed", atom.getAID()));
+			throw new RuntimeException(String.format("Serialization for Atom with ID: %s failed", reAtom.getAID()));
 		}
 	}
 
-	public Atom toAtom(byte[] ledgerEntryContent) {
+	public SimpleRadixEngineAtom toAtom(byte[] ledgerEntryContent) {
 		try {
-			return serializer.fromDson(ledgerEntryContent, Atom.class);
-		} catch (SerializationException e) {
+			Atom rawAtom =  serializer.fromDson(ledgerEntryContent, Atom.class);
+			return RadixEngineUtils.toCMAtom(rawAtom);
+		} catch (SerializationException | CMAtomConversionException e) {
 			throw new RuntimeException("Deserialization of Atom failed");
 		}
 	}

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/converters/AtomToBinaryConverter.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/converters/AtomToBinaryConverter.java
@@ -17,9 +17,7 @@
 
 package com.radixdlt.middleware2.converters;
 
-import com.radixdlt.atommodel.Atom;
 import com.radixdlt.middleware2.LedgerAtom;
-import com.radixdlt.middleware2.LedgerAtom.CMAtomConversionException;
 import com.radixdlt.serialization.DsonOutput;
 import com.radixdlt.serialization.Serialization;
 import com.radixdlt.serialization.SerializationException;
@@ -31,20 +29,19 @@ public final class AtomToBinaryConverter {
 		this.serializer = serializer;
 	}
 
-	public byte[] toLedgerEntryContent(LedgerAtom reAtom) {
+	public byte[] toLedgerEntryContent(LedgerAtom atom) {
 		try {
-			return serializer.toDson(reAtom.getRaw(), DsonOutput.Output.PERSIST);
+			return serializer.toDson(atom, DsonOutput.Output.PERSIST);
 		} catch (SerializationException e) {
-			throw new RuntimeException(String.format("Serialization for Atom with ID: %s failed", reAtom.getAID()));
+			throw new RuntimeException(String.format("Serialization for Atom with ID: %s failed", atom.getAID()));
 		}
 	}
 
 	public LedgerAtom toAtom(byte[] ledgerEntryContent) {
 		try {
-			Atom rawAtom =  serializer.fromDson(ledgerEntryContent, Atom.class);
-			return LedgerAtom.convert(rawAtom);
-		} catch (SerializationException | CMAtomConversionException e) {
-			throw new RuntimeException("Deserialization of Atom failed");
+			return serializer.fromDson(ledgerEntryContent, LedgerAtom.class);
+		} catch (SerializationException e) {
+			throw new RuntimeException("Deserialization of Atom failed", e);
 		}
 	}
 }

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/converters/AtomToLedgerAtomConverter.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/converters/AtomToLedgerAtomConverter.java
@@ -6,7 +6,7 @@
  * compliance with the License.  You may obtain a copy of the
  * License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -15,16 +15,11 @@
  * language governing permissions and limitations under the License.
  */
 
-package com.radixdlt.mempool;
+package com.radixdlt.middleware2.converters;
 
+import com.radixdlt.atommodel.Atom;
 import com.radixdlt.middleware2.LedgerAtom;
 
-/**
- * Exception thrown when an attempt to add new items would
- * exceed the mempool's maximum capacity.
- */
-public class MempoolDuplicateException extends MempoolRejectedException {
-	public MempoolDuplicateException(LedgerAtom atom, String message) {
-		super(atom, message);
-	}
+public interface AtomToLedgerAtomConverter {
+	LedgerAtom convert(Atom atom) throws AtomConversionException;
 }

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/converters/AtomToRadixEngineAtomConverter.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/converters/AtomToRadixEngineAtomConverter.java
@@ -6,7 +6,7 @@
  * compliance with the License.  You may obtain a copy of the
  * License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -15,16 +15,11 @@
  * language governing permissions and limitations under the License.
  */
 
-package com.radixdlt.mempool;
+package com.radixdlt.middleware2.converters;
 
+import com.radixdlt.atommodel.Atom;
 import com.radixdlt.middleware.SimpleRadixEngineAtom;
 
-/**
- * Exception thrown when an attempt to add new items would
- * exceed the mempool's maximum capacity.
- */
-public class MempoolDuplicateException extends MempoolRejectedException {
-	public MempoolDuplicateException(SimpleRadixEngineAtom atom, String message) {
-		super(atom, message);
-	}
+public interface AtomToRadixEngineAtomConverter {
+	SimpleRadixEngineAtom convert(Atom atom) throws AtomConversionException;
 }

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/network/SimpleMempoolNetwork.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/network/SimpleMempoolNetwork.java
@@ -26,7 +26,6 @@ import javax.inject.Inject;
 
 import org.radix.universe.system.LocalSystem;
 
-import com.radixdlt.atommodel.Atom;
 import com.radixdlt.identifiers.EUID;
 import com.radixdlt.mempool.messages.MempoolAtomAddedMessage;
 import com.radixdlt.network.addressbook.AddressBook;
@@ -47,7 +46,7 @@ public class SimpleMempoolNetwork implements MempoolNetworkRx, MempoolNetworkTx 
 	private final AddressBook addressBook;
 	private final MessageCentral messageCentral;
 
-	private final PublishSubject<Atom> atoms;
+	private final PublishSubject<LedgerAtom> atoms;
 
 	@Inject
 	public SimpleMempoolNetwork(
@@ -70,7 +69,7 @@ public class SimpleMempoolNetwork implements MempoolNetworkRx, MempoolNetworkTx 
 
 	@Override
 	public void sendMempoolSubmission(LedgerAtom atom) {
-		MempoolAtomAddedMessage message = new MempoolAtomAddedMessage(this.magic, atom.getRaw());
+		MempoolAtomAddedMessage message = new MempoolAtomAddedMessage(this.magic, atom);
 		final EUID self = this.localPeer.getNID();
 		this.addressBook.peers()
 			.filter(Peer::hasSystem) // Only peers with systems (and therefore transports)
@@ -79,7 +78,7 @@ public class SimpleMempoolNetwork implements MempoolNetworkRx, MempoolNetworkTx 
 	}
 
 	@Override
-	public Observable<Atom> atomMessages() {
+	public Observable<LedgerAtom> atomMessages() {
 		return this.atoms;
 	}
 

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/network/SimpleMempoolNetwork.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/network/SimpleMempoolNetwork.java
@@ -19,6 +19,7 @@ package com.radixdlt.middleware2.network;
 
 import com.radixdlt.mempool.MempoolNetworkRx;
 import com.radixdlt.mempool.MempoolNetworkTx;
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 import java.util.Objects;
 
 import javax.inject.Inject;
@@ -68,8 +69,8 @@ public class SimpleMempoolNetwork implements MempoolNetworkRx, MempoolNetworkTx 
 
 
 	@Override
-	public void sendMempoolSubmission(Atom atom) {
-		MempoolAtomAddedMessage message = new MempoolAtomAddedMessage(this.magic, atom);
+	public void sendMempoolSubmission(SimpleRadixEngineAtom atom) {
+		MempoolAtomAddedMessage message = new MempoolAtomAddedMessage(this.magic, atom.getAtom());
 		final EUID self = this.localPeer.getNID();
 		this.addressBook.peers()
 			.filter(Peer::hasSystem) // Only peers with systems (and therefore transports)

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/network/SimpleMempoolNetwork.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/network/SimpleMempoolNetwork.java
@@ -19,7 +19,7 @@ package com.radixdlt.middleware2.network;
 
 import com.radixdlt.mempool.MempoolNetworkRx;
 import com.radixdlt.mempool.MempoolNetworkTx;
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
 import java.util.Objects;
 
 import javax.inject.Inject;
@@ -69,8 +69,8 @@ public class SimpleMempoolNetwork implements MempoolNetworkRx, MempoolNetworkTx 
 
 
 	@Override
-	public void sendMempoolSubmission(SimpleRadixEngineAtom atom) {
-		MempoolAtomAddedMessage message = new MempoolAtomAddedMessage(this.magic, atom.getAtom());
+	public void sendMempoolSubmission(LedgerAtom atom) {
+		MempoolAtomAddedMessage message = new MempoolAtomAddedMessage(this.magic, atom.getRaw());
 		final EUID self = this.localPeer.getNID();
 		this.addressBook.peers()
 			.filter(Peer::hasSystem) // Only peers with systems (and therefore transports)

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/processing/EngineAtomEventListener.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/processing/EngineAtomEventListener.java
@@ -50,7 +50,7 @@ public class EngineAtomEventListener implements AtomEventListener<SimpleRadixEng
 
 	@Override
 	public void onCMError(SimpleRadixEngineAtom atom, CMError error) {
-		ConstraintMachineValidationException ex = new ConstraintMachineValidationException(atom.getAtom(), error.getErrMsg(), error.getDataPointer());
+		ConstraintMachineValidationException ex = new ConstraintMachineValidationException(atom, error.getErrMsg(), error.getDataPointer());
 		Events.getInstance().broadcast(new AtomExceptionEvent(ex, atom.getAID()));
 	}
 
@@ -71,7 +71,7 @@ public class EngineAtomEventListener implements AtomEventListener<SimpleRadixEng
 
 	@Override
 	public void onVirtualStateConflict(SimpleRadixEngineAtom atom, DataPointer issueParticle) {
-		ConstraintMachineValidationException e = new ConstraintMachineValidationException(atom.getAtom(), "Virtual state conflict", issueParticle);
+		ConstraintMachineValidationException e = new ConstraintMachineValidationException(atom, "Virtual state conflict", issueParticle);
 		log.error("Virtual state conflict", e);
 		Events.getInstance().broadcast(new AtomExceptionEvent(e, atom.getAID()));
 	}

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/processing/EngineAtomEventListener.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/processing/EngineAtomEventListener.java
@@ -57,8 +57,8 @@ public class EngineAtomEventListener implements AtomEventListener<SimpleRadixEng
 	@Override
 	public void onStateStore(SimpleRadixEngineAtom atom) {
 		try {
-			EngineAtomIndices engineAtomIndices = EngineAtomIndices.from(atom.getAtom(), serialization);
-			Events.getInstance().broadcastWithException(new AtomStoredEvent(atom.getAtom(), () ->
+			EngineAtomIndices engineAtomIndices = EngineAtomIndices.from(atom, serialization);
+			Events.getInstance().broadcastWithException(new AtomStoredEvent(atom, () ->
 				engineAtomIndices.getDuplicateIndices().stream()
 					.filter(e -> e.getPrefix() == EngineAtomIndices.IndexType.DESTINATION.getValue())
 					.map(e -> EngineAtomIndices.toEUID(e.asKey()))

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/processing/EngineAtomEventListener.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/processing/EngineAtomEventListener.java
@@ -23,7 +23,7 @@ import com.radixdlt.constraintmachine.CMError;
 import com.radixdlt.constraintmachine.DataPointer;
 import com.radixdlt.constraintmachine.Particle;
 import com.radixdlt.engine.AtomEventListener;
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
 import com.radixdlt.middleware2.store.EngineAtomIndices;
 import com.radixdlt.serialization.Serialization;
 
@@ -40,7 +40,7 @@ import org.radix.validation.ConstraintMachineValidationException;
 import java.util.Collections;
 import java.util.stream.Collectors;
 
-public class EngineAtomEventListener implements AtomEventListener<SimpleRadixEngineAtom> {
+public class EngineAtomEventListener implements AtomEventListener<LedgerAtom> {
 	private static final Logger log = LogManager.getLogger("middleware2.eventListener");
 	private final Serialization serialization;
 
@@ -49,13 +49,13 @@ public class EngineAtomEventListener implements AtomEventListener<SimpleRadixEng
 	}
 
 	@Override
-	public void onCMError(SimpleRadixEngineAtom atom, CMError error) {
+	public void onCMError(LedgerAtom atom, CMError error) {
 		ConstraintMachineValidationException ex = new ConstraintMachineValidationException(atom, error.getErrMsg(), error.getDataPointer());
 		Events.getInstance().broadcast(new AtomExceptionEvent(ex, atom.getAID()));
 	}
 
 	@Override
-	public void onStateStore(SimpleRadixEngineAtom atom) {
+	public void onStateStore(LedgerAtom atom) {
 		try {
 			EngineAtomIndices engineAtomIndices = EngineAtomIndices.from(atom, serialization);
 			Events.getInstance().broadcastWithException(new AtomStoredEvent(atom, () ->
@@ -70,14 +70,14 @@ public class EngineAtomEventListener implements AtomEventListener<SimpleRadixEng
 	}
 
 	@Override
-	public void onVirtualStateConflict(SimpleRadixEngineAtom atom, DataPointer issueParticle) {
+	public void onVirtualStateConflict(LedgerAtom atom, DataPointer issueParticle) {
 		ConstraintMachineValidationException e = new ConstraintMachineValidationException(atom, "Virtual state conflict", issueParticle);
 		log.error("Virtual state conflict", e);
 		Events.getInstance().broadcast(new AtomExceptionEvent(e, atom.getAID()));
 	}
 
 	@Override
-	public void onStateConflict(SimpleRadixEngineAtom atom, DataPointer dp, SimpleRadixEngineAtom conflictingAtom) {
+	public void onStateConflict(LedgerAtom atom, DataPointer dp, LedgerAtom conflictingAtom) {
 		final ParticleConflictException conflict = new ParticleConflictException(
 				new ParticleConflict(dp, ImmutableSet.of(atom.getAID(), conflictingAtom.getAID())
 				));

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/processing/EngineAtomEventListener.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/processing/EngineAtomEventListener.java
@@ -59,7 +59,8 @@ public class EngineAtomEventListener implements AtomEventListener<SimpleRadixEng
 		try {
 			EngineAtomIndices engineAtomIndices = EngineAtomIndices.from(atom.getAtom(), serialization);
 			Events.getInstance().broadcastWithException(new AtomStoredEvent(atom.getAtom(), () ->
-					engineAtomIndices.getDuplicateIndices().stream().filter(e -> e.getPrefix() == EngineAtomIndices.IndexType.DESTINATION.getValue())
+				engineAtomIndices.getDuplicateIndices().stream()
+					.filter(e -> e.getPrefix() == EngineAtomIndices.IndexType.DESTINATION.getValue())
 					.map(e -> EngineAtomIndices.toEUID(e.asKey()))
 					.collect(Collectors.toSet()))
 			);

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/processing/EngineAtomEventListener.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/processing/EngineAtomEventListener.java
@@ -19,7 +19,6 @@ package com.radixdlt.middleware2.processing;
 
 import com.google.common.collect.ImmutableSet;
 import com.radixdlt.identifiers.AID;
-import com.radixdlt.constraintmachine.CMError;
 import com.radixdlt.constraintmachine.DataPointer;
 import com.radixdlt.constraintmachine.Particle;
 import com.radixdlt.engine.AtomEventListener;
@@ -46,12 +45,6 @@ public class EngineAtomEventListener implements AtomEventListener<LedgerAtom> {
 
 	public EngineAtomEventListener(Serialization serialization) {
 		this.serialization = serialization;
-	}
-
-	@Override
-	public void onCMError(LedgerAtom atom, CMError error) {
-		ConstraintMachineValidationException ex = new ConstraintMachineValidationException(atom, error.getErrMsg(), error.getDataPointer());
-		Events.getInstance().broadcast(new AtomExceptionEvent(ex, atom.getAID()));
 	}
 
 	@Override

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/store/EngineAtomIndices.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/store/EngineAtomIndices.java
@@ -22,7 +22,7 @@ import com.radixdlt.identifiers.EUID;
 import com.radixdlt.constraintmachine.CMMicroInstruction;
 import com.radixdlt.constraintmachine.Particle;
 import com.radixdlt.constraintmachine.Spin;
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
 import com.radixdlt.store.StoreIndex;
 import com.radixdlt.serialization.Serialization;
 import com.radixdlt.serialization.SerializationUtils;
@@ -60,7 +60,7 @@ public class EngineAtomIndices {
 		this.duplicateIndices = duplicateIndices;
 	}
 
-	public static EngineAtomIndices from(SimpleRadixEngineAtom radixEngineAtom, Serialization serialization) {
+	public static EngineAtomIndices from(LedgerAtom radixEngineAtom, Serialization serialization) {
 		ImmutableSet.Builder<StoreIndex> uniqueIndices = ImmutableSet.builder();
 		ImmutableSet.Builder<StoreIndex> duplicateIndices = ImmutableSet.builder();
 

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/store/EngineAtomIndices.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/store/EngineAtomIndices.java
@@ -18,14 +18,12 @@
 package com.radixdlt.middleware2.store;
 
 import com.google.common.collect.ImmutableSet;
-import com.radixdlt.atommodel.Atom;
 import com.radixdlt.identifiers.EUID;
 import com.radixdlt.constraintmachine.CMMicroInstruction;
 import com.radixdlt.constraintmachine.Particle;
 import com.radixdlt.constraintmachine.Spin;
-import com.radixdlt.engine.RadixEngineAtom;
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 import com.radixdlt.store.StoreIndex;
-import com.radixdlt.middleware.RadixEngineUtils;
 import com.radixdlt.serialization.Serialization;
 import com.radixdlt.serialization.SerializationUtils;
 import com.radixdlt.store.SpinStateMachine;
@@ -62,13 +60,7 @@ public class EngineAtomIndices {
 		this.duplicateIndices = duplicateIndices;
 	}
 
-	public static EngineAtomIndices from(Atom atom, Serialization serialization) {
-		RadixEngineAtom radixEngineAtom;
-		try {
-			radixEngineAtom = RadixEngineUtils.toCMAtom(atom);
-		} catch (RadixEngineUtils.CMAtomConversionException e) {
-			throw new RuntimeException("EngineAtomIndices creation failed", e);
-		}
+	public static EngineAtomIndices from(SimpleRadixEngineAtom radixEngineAtom, Serialization serialization) {
 		ImmutableSet.Builder<StoreIndex> uniqueIndices = ImmutableSet.builder();
 		ImmutableSet.Builder<StoreIndex> duplicateIndices = ImmutableSet.builder();
 

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/store/LedgerEngineStore.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/store/LedgerEngineStore.java
@@ -89,7 +89,7 @@ public class LedgerEngineStore implements EngineStore<SimpleRadixEngineAtom> {
     public void storeAtom(SimpleRadixEngineAtom reAtom) {
         byte[] binaryAtom = atomToBinaryConverter.toLedgerEntryContent(reAtom.getAtom());
         LedgerEntry ledgerEntry = new LedgerEntry(binaryAtom, reAtom.getAID());
-        EngineAtomIndices engineAtomIndices = EngineAtomIndices.from(reAtom.getAtom(), serialization);
+        EngineAtomIndices engineAtomIndices = EngineAtomIndices.from(reAtom, serialization);
         store.store(ledgerEntry, engineAtomIndices.getUniqueIndices(), engineAtomIndices.getDuplicateIndices());
     }
 

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/store/LedgerEngineStore.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/store/LedgerEngineStore.java
@@ -22,7 +22,7 @@ import com.radixdlt.identifiers.AID;
 import com.radixdlt.identifiers.EUID;
 import com.radixdlt.constraintmachine.Particle;
 import com.radixdlt.constraintmachine.Spin;
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
 import com.radixdlt.serialization.Serialization;
 import com.radixdlt.store.SearchCursor;
 import com.radixdlt.store.StoreIndex;
@@ -39,7 +39,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 
-public class LedgerEngineStore implements EngineStore<SimpleRadixEngineAtom> {
+public class LedgerEngineStore implements EngineStore<LedgerAtom> {
     private static final Logger log = LogManager.getLogger("middleware2.store");
 
     private final Serialization serialization;
@@ -56,12 +56,12 @@ public class LedgerEngineStore implements EngineStore<SimpleRadixEngineAtom> {
     }
 
     @Override
-    public void getAtomContaining(Particle particle, boolean isInput, Consumer<SimpleRadixEngineAtom> callback) {
-        Optional<SimpleRadixEngineAtom> atomOptional = getAtomByParticle(particle, isInput);
+    public void getAtomContaining(Particle particle, boolean isInput, Consumer<LedgerAtom> callback) {
+        Optional<LedgerAtom> atomOptional = getAtomByParticle(particle, isInput);
         atomOptional.ifPresent(callback);
     }
 
-    private Optional<SimpleRadixEngineAtom> getAtomByParticle(Particle particle, boolean isInput) {
+    private Optional<LedgerAtom> getAtomByParticle(Particle particle, boolean isInput) {
         final byte[] indexableBytes = EngineAtomIndices.toByteArray(
         	isInput ? EngineAtomIndices.IndexType.PARTICLE_DOWN : EngineAtomIndices.IndexType.PARTICLE_UP,
         	particle.euid()
@@ -76,7 +76,7 @@ public class LedgerEngineStore implements EngineStore<SimpleRadixEngineAtom> {
     }
 
     @Override
-    public void storeAtom(SimpleRadixEngineAtom reAtom) {
+    public void storeAtom(LedgerAtom reAtom) {
         byte[] binaryAtom = atomToBinaryConverter.toLedgerEntryContent(reAtom);
         LedgerEntry ledgerEntry = new LedgerEntry(binaryAtom, reAtom.getAID());
         EngineAtomIndices engineAtomIndices = EngineAtomIndices.from(reAtom, serialization);

--- a/radixdlt/src/main/java/org/radix/GenerateUniverses.java
+++ b/radixdlt/src/main/java/org/radix/GenerateUniverses.java
@@ -164,7 +164,7 @@ public final class GenerateUniverses {
 		);
 		genesisAtom.sign(universeKey);
 
-		LedgerAtom reAtom = LedgerAtom.convert(genesisAtom);
+		LedgerAtom ledgerAtom = LedgerAtom.convertFromApiAtom(genesisAtom);
 
 		if (standalone) {
 			byte[] sigBytes = serialization.toDson(genesisAtom.getSignature(universeKey.euid()), Output.WIRE);
@@ -177,7 +177,7 @@ public final class GenerateUniverses {
 
 		if (!genesisAtom.verify(universeKey.getPublicKey())) {
 			throw new ConstraintMachineValidationException(
-				reAtom,
+				ledgerAtom,
 				"Signature generation failed - GENESIS TRANSACTION HASH: " + genesisAtom.getHash().toString(),
 				DataPointer.ofAtom()
 			);

--- a/radixdlt/src/main/java/org/radix/GenerateUniverses.java
+++ b/radixdlt/src/main/java/org/radix/GenerateUniverses.java
@@ -22,6 +22,8 @@ import com.radixdlt.DefaultSerialization;
 import com.radixdlt.atommodel.tokens.FixedSupplyTokenDefinitionParticle;
 import com.radixdlt.atommodel.tokens.TokenDefinitionUtils;
 import com.radixdlt.atommodel.Atom;
+import com.radixdlt.middleware.RadixEngineUtils;
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import com.radixdlt.constraintmachine.DataPointer;
 import com.radixdlt.identifiers.RadixAddress;
@@ -164,6 +166,8 @@ public final class GenerateUniverses
 		);
 		genesisAtom.sign(universeKey);
 
+		SimpleRadixEngineAtom reAtom = RadixEngineUtils.toCMAtom(genesisAtom);
+
 		if (standalone) {
 			byte[] sigBytes = serialization.toDson(genesisAtom.getSignature(universeKey.euid()), Output.WIRE);
 			byte[] transactionBytes = serialization.toDson(genesisAtom, Output.HASH);
@@ -175,7 +179,7 @@ public final class GenerateUniverses
 
 		if (!genesisAtom.verify(universeKey.getPublicKey())) {
 			throw new ConstraintMachineValidationException(
-				genesisAtom,
+				reAtom,
 				"Signature generation failed - GENESIS TRANSACTION HASH: " + genesisAtom.getHash().toString(),
 				DataPointer.ofAtom()
 			);

--- a/radixdlt/src/main/java/org/radix/GenerateUniverses.java
+++ b/radixdlt/src/main/java/org/radix/GenerateUniverses.java
@@ -22,8 +22,7 @@ import com.radixdlt.DefaultSerialization;
 import com.radixdlt.atommodel.tokens.FixedSupplyTokenDefinitionParticle;
 import com.radixdlt.atommodel.tokens.TokenDefinitionUtils;
 import com.radixdlt.atommodel.Atom;
-import com.radixdlt.middleware.RadixEngineUtils;
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import com.radixdlt.constraintmachine.DataPointer;
 import com.radixdlt.identifiers.RadixAddress;
@@ -61,8 +60,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
-public final class GenerateUniverses
-{
+public final class GenerateUniverses {
 	private static final Logger LOGGER = LogManager.getLogger("GenerateUniverses");
 
 	public static final String RADIX_ICON_URL = "https://assets.radixdlt.com/icons/icon-xrd-32x32.png";
@@ -166,7 +164,7 @@ public final class GenerateUniverses
 		);
 		genesisAtom.sign(universeKey);
 
-		SimpleRadixEngineAtom reAtom = RadixEngineUtils.toCMAtom(genesisAtom);
+		LedgerAtom reAtom = LedgerAtom.convert(genesisAtom);
 
 		if (standalone) {
 			byte[] sigBytes = serialization.toDson(genesisAtom.getSignature(universeKey.euid()), Output.WIRE);

--- a/radixdlt/src/main/java/org/radix/api/jsonrpc/AtomStatusEpic.java
+++ b/radixdlt/src/main/java/org/radix/api/jsonrpc/AtomStatusEpic.java
@@ -18,6 +18,7 @@
 package org.radix.api.jsonrpc;
 
 import com.radixdlt.engine.AtomStatus;
+import com.radixdlt.engine.RadixEngineException;
 import com.radixdlt.mempool.MempoolDuplicateException;
 import com.radixdlt.mempool.MempoolFullException;
 import com.radixdlt.identifiers.AID;
@@ -104,6 +105,14 @@ public class AtomStatusEpic {
 
 					JSONObject data = new JSONObject();
 					data.put("message", e.getMessage());
+					data.put("pointerToIssue", pointerToIssue);
+					sendAtomSubmissionState.accept(AtomStatus.EVICTED_FAILED_CM_VERIFICATION, data);
+				} else if (e instanceof RadixEngineException) {
+					RadixEngineException reException = (RadixEngineException) e;
+					String pointerToIssue = reException.getDataPointer().toString();
+
+					JSONObject data = new JSONObject();
+					data.put("message", reException.getErrorCode().toString());
 					data.put("pointerToIssue", pointerToIssue);
 					sendAtomSubmissionState.accept(AtomStatus.EVICTED_FAILED_CM_VERIFICATION, data);
 				} else if (e instanceof ConstraintMachineValidationException) {

--- a/radixdlt/src/main/java/org/radix/api/jsonrpc/AtomStatusEpic.java
+++ b/radixdlt/src/main/java/org/radix/api/jsonrpc/AtomStatusEpic.java
@@ -22,6 +22,7 @@ import com.radixdlt.mempool.MempoolDuplicateException;
 import com.radixdlt.mempool.MempoolFullException;
 import com.radixdlt.identifiers.AID;
 import com.radixdlt.identifiers.EUID;
+import com.radixdlt.middleware2.converters.AtomConversionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -97,7 +98,15 @@ public class AtomStatusEpic {
 
 			@Override
 			public void onError(Throwable e) {
-				if (e instanceof ConstraintMachineValidationException) {
+				if (e instanceof AtomConversionException) {
+					AtomConversionException conversionException = (AtomConversionException) e;
+					String pointerToIssue = conversionException.getPointerToIssue();
+
+					JSONObject data = new JSONObject();
+					data.put("message", e.getMessage());
+					data.put("pointerToIssue", pointerToIssue);
+					sendAtomSubmissionState.accept(AtomStatus.EVICTED_FAILED_CM_VERIFICATION, data);
+				} else if (e instanceof ConstraintMachineValidationException) {
 					ConstraintMachineValidationException cmException = (ConstraintMachineValidationException) e;
 					String pointerToIssue = cmException.getPointerToIssue();
 

--- a/radixdlt/src/main/java/org/radix/api/observable/AtomEventObserver.java
+++ b/radixdlt/src/main/java/org/radix/api/observable/AtomEventObserver.java
@@ -20,7 +20,7 @@ package org.radix.api.observable;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.radixdlt.identifiers.AID;
-import com.radixdlt.atommodel.Atom;
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 import com.radixdlt.store.SearchCursor;
 import com.radixdlt.store.StoreIndex;
 import com.radixdlt.store.LedgerSearchMode;
@@ -147,14 +147,14 @@ public class AtomEventObserver {
 					return;
 				}
 
-				List<Atom> atoms = new ArrayList<>();
+				List<SimpleRadixEngineAtom> atoms = new ArrayList<>();
 				while (cursor != null && atoms.size() < BATCH_SIZE) {
 					AID aid = cursor.get();
 					processedAids.add(aid);
 					Optional<LedgerEntry> ledgerEntry = store.get(aid);
 					ledgerEntry.ifPresent(
 						entry -> {
-							Atom atom = atomToBinaryConverter.toAtom(entry.getContent());
+							SimpleRadixEngineAtom atom = atomToBinaryConverter.toAtom(entry.getContent());
 							atoms.add(atom);
 						}
 					);
@@ -162,7 +162,7 @@ public class AtomEventObserver {
 				}
 				if (!atoms.isEmpty()) {
 					final Stream<AtomEventDto> atomEvents = atoms.stream()
-						.map(atom -> new AtomEventDto(AtomEventType.STORE, atom));
+						.map(atom -> new AtomEventDto(AtomEventType.STORE, atom.getAtom()));
 					onNext.accept(new ObservedAtomEvents(false, atomEvents));
 					count += atoms.size();
 				}

--- a/radixdlt/src/main/java/org/radix/api/observable/AtomEventObserver.java
+++ b/radixdlt/src/main/java/org/radix/api/observable/AtomEventObserver.java
@@ -19,11 +19,9 @@ package org.radix.api.observable;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import com.radixdlt.DefaultSerialization;
 import com.radixdlt.atommodel.Atom;
 import com.radixdlt.identifiers.AID;
 import com.radixdlt.middleware2.LedgerAtom;
-import com.radixdlt.serialization.SerializationException;
 import com.radixdlt.store.SearchCursor;
 import com.radixdlt.store.StoreIndex;
 import com.radixdlt.store.LedgerSearchMode;

--- a/radixdlt/src/main/java/org/radix/api/observable/AtomEventObserver.java
+++ b/radixdlt/src/main/java/org/radix/api/observable/AtomEventObserver.java
@@ -111,7 +111,7 @@ public class AtomEventObserver {
 		if (atomEvent instanceof AtomStoredEvent) {
 			if (atomQuery.filter(atomEvent.getDestinations())) {
 				final AtomEventType atomEventType = atomEvent instanceof AtomStoredEvent ? AtomEventType.STORE : AtomEventType.DELETE;
-				final AtomEventDto atomEventDto = new AtomEventDto(atomEventType, atomEvent.getAtom());
+				final AtomEventDto atomEventDto = new AtomEventDto(atomEventType, atomEvent.getAtom().getAtom());
 				synchronized (this) {
 					this.currentRunnable = currentRunnable.thenRunAsync(() -> update(atomEventDto), executorService);
 				}

--- a/radixdlt/src/main/java/org/radix/api/services/AtomsService.java
+++ b/radixdlt/src/main/java/org/radix/api/services/AtomsService.java
@@ -42,6 +42,7 @@ import com.radixdlt.serialization.Serialization;
 import com.radixdlt.store.LedgerEntry;
 import com.radixdlt.store.LedgerEntryStore;
 
+import java.util.concurrent.atomic.AtomicReference;
 import org.json.JSONException;
 import org.json.JSONObject;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -170,7 +171,12 @@ public class AtomsService {
 
 	public AID submitAtom(JSONObject jsonAtom, SingleAtomListener subscriber) {
 		try {
-			return this.submissionControl.submitAtom(jsonAtom, atom -> subscribeToSubmission(subscriber, atom));
+			AtomicReference<AID> aid = new AtomicReference<>();
+			this.submissionControl.submitAtom(jsonAtom, atom -> {
+				aid.set(atom.getAID());
+				subscribeToSubmission(subscriber, atom);
+			});
+			return aid.get();
 		} catch (MempoolRejectedException e) {
 			if (subscriber != null) {
 				AID atomId = e.atom().getAID();

--- a/radixdlt/src/main/java/org/radix/api/services/AtomsService.java
+++ b/radixdlt/src/main/java/org/radix/api/services/AtomsService.java
@@ -23,6 +23,7 @@ import com.radixdlt.atommodel.Atom;
 import com.radixdlt.mempool.MempoolRejectedException;
 import com.radixdlt.mempool.SubmissionControl;
 
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -93,7 +94,7 @@ public class AtomsService {
 				}
 
 				final AtomEvent atomEvent = (AtomEvent) event;
-				final Atom atom = atomEvent.getAtom();
+				final SimpleRadixEngineAtom atom = atomEvent.getAtom();
 
 				// TODO: Clean this up
 				final String eventName;

--- a/radixdlt/src/main/java/org/radix/api/services/AtomsService.java
+++ b/radixdlt/src/main/java/org/radix/api/services/AtomsService.java
@@ -23,7 +23,7 @@ import com.radixdlt.atommodel.Atom;
 import com.radixdlt.mempool.MempoolRejectedException;
 import com.radixdlt.mempool.SubmissionControl;
 
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -94,7 +94,7 @@ public class AtomsService {
 				}
 
 				final AtomEvent atomEvent = (AtomEvent) event;
-				final SimpleRadixEngineAtom atom = atomEvent.getAtom();
+				final LedgerAtom atom = atomEvent.getAtom();
 
 				// TODO: Clean this up
 				final String eventName;
@@ -225,8 +225,8 @@ public class AtomsService {
 		Optional<LedgerEntry> ledgerEntryOptional = store.get(atomId);
 		if (ledgerEntryOptional.isPresent()) {
 			LedgerEntry ledgerEntry = ledgerEntryOptional.get();
-			SimpleRadixEngineAtom atom = atomToBinaryConverter.toAtom(ledgerEntry.getContent());
-			return serialization.toJsonObject(atom.getAtom(), DsonOutput.Output.API);
+			LedgerAtom atom = atomToBinaryConverter.toAtom(ledgerEntry.getContent());
+			return serialization.toJsonObject(atom.getRaw(), DsonOutput.Output.API);
 		}
 		throw new RuntimeException("Atom not found");
 	}

--- a/radixdlt/src/main/java/org/radix/api/services/AtomsService.java
+++ b/radixdlt/src/main/java/org/radix/api/services/AtomsService.java
@@ -225,8 +225,8 @@ public class AtomsService {
 		Optional<LedgerEntry> ledgerEntryOptional = store.get(atomId);
 		if (ledgerEntryOptional.isPresent()) {
 			LedgerEntry ledgerEntry = ledgerEntryOptional.get();
-			Atom atom = atomToBinaryConverter.toAtom(ledgerEntry.getContent());
-			return serialization.toJsonObject(atom, DsonOutput.Output.API);
+			SimpleRadixEngineAtom atom = atomToBinaryConverter.toAtom(ledgerEntry.getContent());
+			return serialization.toJsonObject(atom.getAtom(), DsonOutput.Output.API);
 		}
 		throw new RuntimeException("Atom not found");
 	}

--- a/radixdlt/src/main/java/org/radix/api/services/AtomsService.java
+++ b/radixdlt/src/main/java/org/radix/api/services/AtomsService.java
@@ -184,7 +184,7 @@ public class AtomsService {
 		}
 	}
 
-	private void subscribeToSubmission(SingleAtomListener subscriber, Atom atom) {
+	private void subscribeToSubmission(SingleAtomListener subscriber, LedgerAtom atom) {
 		if (subscriber != null) {
 			this.deleteOnEventSingleAtomObservers.compute(atom.getAID(), (aid, oldSubscribers) -> {
 				List<SingleAtomListener> subscribers = oldSubscribers == null ? new ArrayList<>() : oldSubscribers;

--- a/radixdlt/src/main/java/org/radix/api/services/AtomsService.java
+++ b/radixdlt/src/main/java/org/radix/api/services/AtomsService.java
@@ -226,7 +226,8 @@ public class AtomsService {
 		if (ledgerEntryOptional.isPresent()) {
 			LedgerEntry ledgerEntry = ledgerEntryOptional.get();
 			LedgerAtom atom = atomToBinaryConverter.toAtom(ledgerEntry.getContent());
-			return serialization.toJsonObject(atom.getRaw(), DsonOutput.Output.API);
+			Atom apiAtom = LedgerAtom.convertToApiAtom(atom);
+			return serialization.toJsonObject(apiAtom, DsonOutput.Output.API);
 		}
 		throw new RuntimeException("Atom not found");
 	}

--- a/radixdlt/src/main/java/org/radix/api/services/InternalService.java
+++ b/radixdlt/src/main/java/org/radix/api/services/InternalService.java
@@ -17,6 +17,7 @@
 
 package org.radix.api.services;
 
+import com.radixdlt.middleware2.LedgerAtom;
 import java.util.Random;
 
 import org.apache.logging.log4j.LogManager;
@@ -123,7 +124,8 @@ public final class InternalService {
 
 							atom.sign(this.owner);
 
-							submissionControl.submitAtom(atom);
+							LedgerAtom ledgerAtom = LedgerAtom.convert(atom);
+							submissionControl.submitAtom(ledgerAtom);
 
 							remainingIterations--;
 							if (remainingIterations <= 0) {

--- a/radixdlt/src/main/java/org/radix/api/services/InternalService.java
+++ b/radixdlt/src/main/java/org/radix/api/services/InternalService.java
@@ -124,7 +124,7 @@ public final class InternalService {
 
 							atom.sign(this.owner);
 
-							LedgerAtom ledgerAtom = LedgerAtom.convert(atom);
+							LedgerAtom ledgerAtom = LedgerAtom.convertFromApiAtom(atom);
 							submissionControl.submitAtom(ledgerAtom);
 
 							remainingIterations--;

--- a/radixdlt/src/main/java/org/radix/atoms/events/AtomEvent.java
+++ b/radixdlt/src/main/java/org/radix/atoms/events/AtomEvent.java
@@ -17,20 +17,20 @@
 
 package org.radix.atoms.events;
 
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
 import org.radix.common.Syncronicity;
 import org.radix.events.Event;
 
 public abstract class AtomEvent extends Event {
-	private final SimpleRadixEngineAtom atom;
+	private final LedgerAtom atom;
 
-	public AtomEvent(SimpleRadixEngineAtom atom) {
+	public AtomEvent(LedgerAtom atom) {
 		super();
 
 		this.atom = atom;
 	}
 
-	public SimpleRadixEngineAtom getAtom() {
+	public LedgerAtom getAtom() {
 		return atom;
 	}
 

--- a/radixdlt/src/main/java/org/radix/atoms/events/AtomEvent.java
+++ b/radixdlt/src/main/java/org/radix/atoms/events/AtomEvent.java
@@ -17,23 +17,20 @@
 
 package org.radix.atoms.events;
 
-import com.radixdlt.atommodel.Atom;
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 import org.radix.common.Syncronicity;
 import org.radix.events.Event;
 
-public abstract class AtomEvent extends Event
-{
-	private final Atom atom;
+public abstract class AtomEvent extends Event {
+	private final SimpleRadixEngineAtom atom;
 
-	public AtomEvent(Atom atom)
-	{
+	public AtomEvent(SimpleRadixEngineAtom atom) {
 		super();
 
 		this.atom = atom;
 	}
 
-	public Atom getAtom()
-	{
+	public SimpleRadixEngineAtom getAtom() {
 		return atom;
 	}
 

--- a/radixdlt/src/main/java/org/radix/atoms/events/AtomEventWithDestinations.java
+++ b/radixdlt/src/main/java/org/radix/atoms/events/AtomEventWithDestinations.java
@@ -17,16 +17,16 @@
 
 package org.radix.atoms.events;
 
-import com.radixdlt.atommodel.Atom;
 import com.radixdlt.identifiers.EUID;
 
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 import java.util.Set;
 import java.util.function.Supplier;
 
 public class AtomEventWithDestinations extends AtomEvent {
 	private Set<EUID> destinations;
 
-	public AtomEventWithDestinations(Atom atom, Supplier<Set<EUID>> destinationsSupplier) {
+	public AtomEventWithDestinations(SimpleRadixEngineAtom atom, Supplier<Set<EUID>> destinationsSupplier) {
 		super(atom);
 		this.destinations = destinationsSupplier.get();
 	}

--- a/radixdlt/src/main/java/org/radix/atoms/events/AtomEventWithDestinations.java
+++ b/radixdlt/src/main/java/org/radix/atoms/events/AtomEventWithDestinations.java
@@ -19,14 +19,14 @@ package org.radix.atoms.events;
 
 import com.radixdlt.identifiers.EUID;
 
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
 import java.util.Set;
 import java.util.function.Supplier;
 
 public class AtomEventWithDestinations extends AtomEvent {
 	private Set<EUID> destinations;
 
-	public AtomEventWithDestinations(SimpleRadixEngineAtom atom, Supplier<Set<EUID>> destinationsSupplier) {
+	public AtomEventWithDestinations(LedgerAtom atom, Supplier<Set<EUID>> destinationsSupplier) {
 		super(atom);
 		this.destinations = destinationsSupplier.get();
 	}

--- a/radixdlt/src/main/java/org/radix/atoms/events/AtomStoredEvent.java
+++ b/radixdlt/src/main/java/org/radix/atoms/events/AtomStoredEvent.java
@@ -17,15 +17,15 @@
 
 package org.radix.atoms.events;
 
-import com.radixdlt.atommodel.Atom;
 import com.radixdlt.identifiers.EUID;
 
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 import java.util.Set;
 import java.util.function.Supplier;
 
 public final class AtomStoredEvent extends AtomEventWithDestinations {
 
-	public AtomStoredEvent(Atom atom, Supplier<Set<EUID>> destinationsSupplier) {
+	public AtomStoredEvent(SimpleRadixEngineAtom atom, Supplier<Set<EUID>> destinationsSupplier) {
 		super(atom, destinationsSupplier);
 	}
 }

--- a/radixdlt/src/main/java/org/radix/atoms/events/AtomStoredEvent.java
+++ b/radixdlt/src/main/java/org/radix/atoms/events/AtomStoredEvent.java
@@ -19,13 +19,13 @@ package org.radix.atoms.events;
 
 import com.radixdlt.identifiers.EUID;
 
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
 import java.util.Set;
 import java.util.function.Supplier;
 
 public final class AtomStoredEvent extends AtomEventWithDestinations {
 
-	public AtomStoredEvent(SimpleRadixEngineAtom atom, Supplier<Set<EUID>> destinationsSupplier) {
+	public AtomStoredEvent(LedgerAtom atom, Supplier<Set<EUID>> destinationsSupplier) {
 		super(atom, destinationsSupplier);
 	}
 }

--- a/radixdlt/src/main/java/org/radix/validation/ConstraintMachineValidationException.java
+++ b/radixdlt/src/main/java/org/radix/validation/ConstraintMachineValidationException.java
@@ -17,20 +17,19 @@
 
 package org.radix.validation;
 
-import com.radixdlt.atommodel.Atom;
-
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 import java.util.Objects;
 import com.radixdlt.constraintmachine.DataPointer;
 import org.radix.exceptions.ValidationException;
 
 /**
- * An exception during validation of an {@link Atom}
+ * An exception during validation of an {@link SimpleRadixEngineAtom}
  */
 public class ConstraintMachineValidationException extends ValidationException {
-	private final Atom atom;
+	private final SimpleRadixEngineAtom atom;
 	private final DataPointer dataPointer;
 
-	public ConstraintMachineValidationException(Atom atom, String message, DataPointer dataPointer) {
+	public ConstraintMachineValidationException(SimpleRadixEngineAtom atom, String message, DataPointer dataPointer) {
 		super(message);
 
 		Objects.requireNonNull(atom);
@@ -44,7 +43,7 @@ public class ConstraintMachineValidationException extends ValidationException {
 		return dataPointer.toString();
 	}
 
-	public Atom getAtom() {
+	public SimpleRadixEngineAtom getAtom() {
 		return atom;
 	}
 }

--- a/radixdlt/src/main/java/org/radix/validation/ConstraintMachineValidationException.java
+++ b/radixdlt/src/main/java/org/radix/validation/ConstraintMachineValidationException.java
@@ -17,19 +17,19 @@
 
 package org.radix.validation;
 
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
 import java.util.Objects;
 import com.radixdlt.constraintmachine.DataPointer;
 import org.radix.exceptions.ValidationException;
 
 /**
- * An exception during validation of an {@link SimpleRadixEngineAtom}
+ * An exception during validation of an {@link LedgerAtom}
  */
 public class ConstraintMachineValidationException extends ValidationException {
-	private final SimpleRadixEngineAtom atom;
+	private final LedgerAtom atom;
 	private final DataPointer dataPointer;
 
-	public ConstraintMachineValidationException(SimpleRadixEngineAtom atom, String message, DataPointer dataPointer) {
+	public ConstraintMachineValidationException(LedgerAtom atom, String message, DataPointer dataPointer) {
 		super(message);
 
 		Objects.requireNonNull(atom);
@@ -43,7 +43,7 @@ public class ConstraintMachineValidationException extends ValidationException {
 		return dataPointer.toString();
 	}
 
-	public SimpleRadixEngineAtom getAtom() {
+	public LedgerAtom getAtom() {
 		return atom;
 	}
 }

--- a/radixdlt/src/test/java/com/radixdlt/consensus/BFTEventReducerTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/BFTEventReducerTest.java
@@ -33,7 +33,7 @@ import com.radixdlt.crypto.Hash;
 import com.radixdlt.engine.RadixEngineErrorCode;
 import com.radixdlt.engine.RadixEngineException;
 import com.radixdlt.mempool.Mempool;
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
 import com.radixdlt.utils.Ints;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -188,7 +188,7 @@ public class BFTEventReducerTest {
 		View currentView = View.of(123);
 
 		Vertex proposedVertex = mock(Vertex.class);
-		SimpleRadixEngineAtom proposedAtom = mock(SimpleRadixEngineAtom.class);
+		LedgerAtom proposedAtom = mock(LedgerAtom.class);
 		AID aid = makeAID(7); // no special significance
 		when(proposedAtom.getAID()).thenReturn(aid);
 		when(proposedVertex.getAtom()).thenReturn(proposedAtom);
@@ -213,7 +213,7 @@ public class BFTEventReducerTest {
 		when(proposerElection.getProposer(any())).thenReturn(ECKeyPair.generateNew().getPublicKey());
 
 		Vertex proposedVertex = mock(Vertex.class);
-		SimpleRadixEngineAtom proposedAtom = mock(SimpleRadixEngineAtom.class);
+		LedgerAtom proposedAtom = mock(LedgerAtom.class);
 		AID aid = makeAID(7); // no special significance
 		when(proposedAtom.getAID()).thenReturn(aid);
 		when(proposedVertex.getAtom()).thenReturn(proposedAtom);
@@ -246,7 +246,7 @@ public class BFTEventReducerTest {
 		when(proposerElection.getProposer(eq(currentView.next()))).thenReturn(SELF_KEY.getPublicKey());
 
 		Vertex proposedVertex = mock(Vertex.class);
-		SimpleRadixEngineAtom proposedAtom = mock(SimpleRadixEngineAtom.class);
+		LedgerAtom proposedAtom = mock(LedgerAtom.class);
 		AID aid = makeAID(7); // no special significance
 		when(proposedAtom.getAID()).thenReturn(aid);
 		when(proposedVertex.getAtom()).thenReturn(proposedAtom);
@@ -278,7 +278,7 @@ public class BFTEventReducerTest {
 		when(proposerElection.getProposer(eq(currentView))).thenReturn(SELF_KEY.getPublicKey());
 
 		Vertex proposedVertex = mock(Vertex.class);
-		SimpleRadixEngineAtom proposedAtom = mock(SimpleRadixEngineAtom.class);
+		LedgerAtom proposedAtom = mock(LedgerAtom.class);
 		AID aid = makeAID(7); // no special significance
 		when(proposedAtom.getAID()).thenReturn(aid);
 		when(proposedVertex.getAtom()).thenReturn(proposedAtom);
@@ -324,7 +324,7 @@ public class BFTEventReducerTest {
 
 		Hash committedVertexId = mock(Hash.class);
 		Vertex committedVertex = mock(Vertex.class);
-		SimpleRadixEngineAtom atom = mock(SimpleRadixEngineAtom.class);
+		LedgerAtom atom = mock(LedgerAtom.class);
 		AID aid = mock(AID.class);
 		when(atom.getAID()).thenReturn(aid);
 		when(committedVertex.getAtom()).thenReturn(atom);

--- a/radixdlt/src/test/java/com/radixdlt/consensus/BFTEventReducerTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/BFTEventReducerTest.java
@@ -20,7 +20,6 @@ package com.radixdlt.consensus;
 import com.google.common.collect.Lists;
 import com.radixdlt.consensus.liveness.ProposalGenerator;
 import com.radixdlt.identifiers.AID;
-import com.radixdlt.atommodel.Atom;
 import com.radixdlt.consensus.liveness.Pacemaker;
 import com.radixdlt.consensus.liveness.ProposerElection;
 import com.radixdlt.consensus.safety.SafetyRules;
@@ -34,6 +33,7 @@ import com.radixdlt.crypto.Hash;
 import com.radixdlt.engine.RadixEngineErrorCode;
 import com.radixdlt.engine.RadixEngineException;
 import com.radixdlt.mempool.Mempool;
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 import com.radixdlt.utils.Ints;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -188,7 +188,7 @@ public class BFTEventReducerTest {
 		View currentView = View.of(123);
 
 		Vertex proposedVertex = mock(Vertex.class);
-		Atom proposedAtom = mock(Atom.class);
+		SimpleRadixEngineAtom proposedAtom = mock(SimpleRadixEngineAtom.class);
 		AID aid = makeAID(7); // no special significance
 		when(proposedAtom.getAID()).thenReturn(aid);
 		when(proposedVertex.getAtom()).thenReturn(proposedAtom);
@@ -213,7 +213,7 @@ public class BFTEventReducerTest {
 		when(proposerElection.getProposer(any())).thenReturn(ECKeyPair.generateNew().getPublicKey());
 
 		Vertex proposedVertex = mock(Vertex.class);
-		Atom proposedAtom = mock(Atom.class);
+		SimpleRadixEngineAtom proposedAtom = mock(SimpleRadixEngineAtom.class);
 		AID aid = makeAID(7); // no special significance
 		when(proposedAtom.getAID()).thenReturn(aid);
 		when(proposedVertex.getAtom()).thenReturn(proposedAtom);
@@ -246,7 +246,7 @@ public class BFTEventReducerTest {
 		when(proposerElection.getProposer(eq(currentView.next()))).thenReturn(SELF_KEY.getPublicKey());
 
 		Vertex proposedVertex = mock(Vertex.class);
-		Atom proposedAtom = mock(Atom.class);
+		SimpleRadixEngineAtom proposedAtom = mock(SimpleRadixEngineAtom.class);
 		AID aid = makeAID(7); // no special significance
 		when(proposedAtom.getAID()).thenReturn(aid);
 		when(proposedVertex.getAtom()).thenReturn(proposedAtom);
@@ -278,7 +278,7 @@ public class BFTEventReducerTest {
 		when(proposerElection.getProposer(eq(currentView))).thenReturn(SELF_KEY.getPublicKey());
 
 		Vertex proposedVertex = mock(Vertex.class);
-		Atom proposedAtom = mock(Atom.class);
+		SimpleRadixEngineAtom proposedAtom = mock(SimpleRadixEngineAtom.class);
 		AID aid = makeAID(7); // no special significance
 		when(proposedAtom.getAID()).thenReturn(aid);
 		when(proposedVertex.getAtom()).thenReturn(proposedAtom);
@@ -324,7 +324,7 @@ public class BFTEventReducerTest {
 
 		Hash committedVertexId = mock(Hash.class);
 		Vertex committedVertex = mock(Vertex.class);
-		Atom atom = mock(Atom.class);
+		SimpleRadixEngineAtom atom = mock(SimpleRadixEngineAtom.class);
 		AID aid = mock(AID.class);
 		when(atom.getAID()).thenReturn(aid);
 		when(committedVertex.getAtom()).thenReturn(atom);

--- a/radixdlt/src/test/java/com/radixdlt/consensus/VertexStoreTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/VertexStoreTest.java
@@ -29,7 +29,7 @@ import com.radixdlt.crypto.ECDSASignatures;
 import com.radixdlt.crypto.Hash;
 import com.radixdlt.engine.RadixEngine;
 import com.radixdlt.engine.RadixEngineException;
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
 import io.reactivex.rxjava3.observers.TestObserver;
 import java.util.Arrays;
 import org.junit.Before;
@@ -41,7 +41,7 @@ public class VertexStoreTest {
 	private VertexMetadata genesisVertexMetadata;
 	private QuorumCertificate rootQC;
 	private VertexStore vertexStore;
-	private RadixEngine<SimpleRadixEngineAtom> radixEngine;
+	private RadixEngine<LedgerAtom> radixEngine;
 
 	@Before
 	public void setUp() {
@@ -91,7 +91,7 @@ public class VertexStoreTest {
 		VertexMetadata vertexMetadata = new VertexMetadata(View.genesis(), Hash.ZERO_HASH, 0);
 		VoteData voteData = new VoteData(vertexMetadata, null);
 		QuorumCertificate qc = new QuorumCertificate(voteData, new ECDSASignatures());
-		Vertex nextVertex = Vertex.createVertex(qc, View.of(1), mock(SimpleRadixEngineAtom.class));
+		Vertex nextVertex = Vertex.createVertex(qc, View.of(1), mock(LedgerAtom.class));
 		assertThatThrownBy(() -> vertexStore.insertVertex(nextVertex))
 			.isInstanceOf(MissingParentException.class);
 	}
@@ -101,7 +101,7 @@ public class VertexStoreTest {
 	public void when_inserting_vertex_which_fails_to_pass_re__then_vertex_insertion_exception_is_thrown() throws Exception {
 		doThrow(mock(RadixEngineException.class)).when(radixEngine).store(any());
 
-		Vertex nextVertex = Vertex.createVertex(rootQC, View.of(1), mock(SimpleRadixEngineAtom.class));
+		Vertex nextVertex = Vertex.createVertex(rootQC, View.of(1), mock(LedgerAtom.class));
 		assertThatThrownBy(() -> vertexStore.insertVertex(nextVertex))
 			.isInstanceOf(VertexInsertionException.class);
 	}

--- a/radixdlt/src/test/java/com/radixdlt/consensus/VertexStoreTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/VertexStoreTest.java
@@ -24,12 +24,12 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.radixdlt.atommodel.Atom;
 import com.radixdlt.counters.SystemCounters;
 import com.radixdlt.crypto.ECDSASignatures;
 import com.radixdlt.crypto.Hash;
 import com.radixdlt.engine.RadixEngine;
 import com.radixdlt.engine.RadixEngineException;
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 import io.reactivex.rxjava3.observers.TestObserver;
 import java.util.Arrays;
 import org.junit.Before;
@@ -41,7 +41,7 @@ public class VertexStoreTest {
 	private VertexMetadata genesisVertexMetadata;
 	private QuorumCertificate rootQC;
 	private VertexStore vertexStore;
-	private RadixEngine radixEngine;
+	private RadixEngine<SimpleRadixEngineAtom> radixEngine;
 
 	@Before
 	public void setUp() {
@@ -91,7 +91,7 @@ public class VertexStoreTest {
 		VertexMetadata vertexMetadata = new VertexMetadata(View.genesis(), Hash.ZERO_HASH, 0);
 		VoteData voteData = new VoteData(vertexMetadata, null);
 		QuorumCertificate qc = new QuorumCertificate(voteData, new ECDSASignatures());
-		Vertex nextVertex = Vertex.createVertex(qc, View.of(1), mock(Atom.class));
+		Vertex nextVertex = Vertex.createVertex(qc, View.of(1), mock(SimpleRadixEngineAtom.class));
 		assertThatThrownBy(() -> vertexStore.insertVertex(nextVertex))
 			.isInstanceOf(MissingParentException.class);
 	}
@@ -101,7 +101,7 @@ public class VertexStoreTest {
 	public void when_inserting_vertex_which_fails_to_pass_re__then_vertex_insertion_exception_is_thrown() throws Exception {
 		doThrow(mock(RadixEngineException.class)).when(radixEngine).store(any());
 
-		Vertex nextVertex = Vertex.createVertex(rootQC, View.of(1), mock(Atom.class));
+		Vertex nextVertex = Vertex.createVertex(rootQC, View.of(1), mock(SimpleRadixEngineAtom.class));
 		assertThatThrownBy(() -> vertexStore.insertVertex(nextVertex))
 			.isInstanceOf(VertexInsertionException.class);
 	}

--- a/radixdlt/src/test/java/com/radixdlt/consensus/VertexTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/VertexTest.java
@@ -17,7 +17,6 @@
 
 package com.radixdlt.consensus;
 
-import com.radixdlt.atommodel.Atom;
 import com.radixdlt.crypto.ECDSASignatures;
 import com.radixdlt.crypto.Hash;
 import com.radixdlt.middleware2.LedgerAtom;
@@ -30,14 +29,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
 
 public class VertexTest {
 
 	private Vertex testObject;
 	private QuorumCertificate qc;
 	private LedgerAtom atom;
-	private Atom rawAtom;
 
 	@Before
 	public void setUp() {
@@ -50,9 +47,7 @@ public class VertexTest {
 
 		this.qc = new QuorumCertificate(voteData, new ECDSASignatures());
 
-		this.rawAtom = mock(Atom.class);
 		this.atom = mock(LedgerAtom.class);
-		when(atom.getRaw()).thenReturn(rawAtom);
 
 		this.testObject = Vertex.createVertex(this.qc, baseView.next().next(), this.atom);
 	}

--- a/radixdlt/src/test/java/com/radixdlt/consensus/VertexTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/VertexTest.java
@@ -20,6 +20,7 @@ package com.radixdlt.consensus;
 import com.radixdlt.atommodel.Atom;
 import com.radixdlt.crypto.ECDSASignatures;
 import com.radixdlt.crypto.Hash;
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Before;
 import org.junit.Test;
@@ -28,12 +29,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
 
 public class VertexTest {
 
 	private Vertex testObject;
 	private QuorumCertificate qc;
-	private Atom atom;
+	private SimpleRadixEngineAtom atom;
+	private Atom rawAtom;
 
 	@Before
 	public void setUp() {
@@ -46,7 +50,9 @@ public class VertexTest {
 
 		this.qc = new QuorumCertificate(voteData, new ECDSASignatures());
 
-		this.atom = new Atom();
+		this.rawAtom = mock(Atom.class);
+		this.atom = mock(SimpleRadixEngineAtom.class);
+		when(atom.getAtom()).thenReturn(rawAtom);
 
 		this.testObject = Vertex.createVertex(this.qc, baseView.next().next(), this.atom);
 	}
@@ -71,16 +77,15 @@ public class VertexTest {
 		VertexMetadata parent = new VertexMetadata(baseView, Hash.random(), 0);
 		VoteData voteData = new VoteData(vertexMetadata, parent);
 		QuorumCertificate qc2 = new QuorumCertificate(voteData, new ECDSASignatures());
-		Atom atom2 = new Atom();
 
-		Vertex v = Vertex.createVertex(qc2, baseView.next().next().next(), atom2);
+		Vertex v = Vertex.createVertex(qc2, baseView.next().next().next(), null);
 
 		assertFalse(v.hasDirectParent());
 	}
 
 	@Test
 	public void testGetters() {
-		assertEquals(this.atom, this.testObject.getAtom());
+		assertEquals(this.rawAtom, this.testObject.getRawAtom());
 		assertEquals(this.qc, this.testObject.getQC());
 		assertEquals(View.of(1234567892L), this.testObject.getView());
 	}

--- a/radixdlt/src/test/java/com/radixdlt/consensus/VertexTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/VertexTest.java
@@ -20,7 +20,7 @@ package com.radixdlt.consensus;
 import com.radixdlt.atommodel.Atom;
 import com.radixdlt.crypto.ECDSASignatures;
 import com.radixdlt.crypto.Hash;
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,7 +36,7 @@ public class VertexTest {
 
 	private Vertex testObject;
 	private QuorumCertificate qc;
-	private SimpleRadixEngineAtom atom;
+	private LedgerAtom atom;
 	private Atom rawAtom;
 
 	@Before
@@ -51,8 +51,8 @@ public class VertexTest {
 		this.qc = new QuorumCertificate(voteData, new ECDSASignatures());
 
 		this.rawAtom = mock(Atom.class);
-		this.atom = mock(SimpleRadixEngineAtom.class);
-		when(atom.getAtom()).thenReturn(rawAtom);
+		this.atom = mock(LedgerAtom.class);
+		when(atom.getRaw()).thenReturn(rawAtom);
 
 		this.testObject = Vertex.createVertex(this.qc, baseView.next().next(), this.atom);
 	}

--- a/radixdlt/src/test/java/com/radixdlt/consensus/VertexTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/VertexTest.java
@@ -85,7 +85,7 @@ public class VertexTest {
 
 	@Test
 	public void testGetters() {
-		assertEquals(this.rawAtom, this.testObject.getRawAtom());
+		assertEquals(this.atom, this.testObject.getAtom());
 		assertEquals(this.qc, this.testObject.getQC());
 		assertEquals(View.of(1234567892L), this.testObject.getView());
 	}

--- a/radixdlt/src/test/java/com/radixdlt/consensus/liveness/MempoolProposalGeneratorTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/liveness/MempoolProposalGeneratorTest.java
@@ -24,7 +24,6 @@ import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.radixdlt.atommodel.Atom;
 import com.radixdlt.consensus.QuorumCertificate;
 import com.radixdlt.consensus.Vertex;
 import com.radixdlt.consensus.VertexMetadata;
@@ -39,9 +38,7 @@ public class MempoolProposalGeneratorTest {
 	@Test
 	public void when_vertex_store_contains_vertices_with_no_atom__then_generate_proposal_should_still_work() {
 		Mempool mempool = mock(Mempool.class);
-		Atom atom = mock(Atom.class);
 		LedgerAtom reAtom = mock(LedgerAtom.class);
-		when(reAtom.getRaw()).thenReturn(atom);
 		when(mempool.getAtoms(anyInt(), anySet())).thenReturn(Collections.singletonList(reAtom));
 
 		VertexStore vertexStore = mock(VertexStore.class);

--- a/radixdlt/src/test/java/com/radixdlt/consensus/liveness/MempoolProposalGeneratorTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/liveness/MempoolProposalGeneratorTest.java
@@ -31,7 +31,7 @@ import com.radixdlt.consensus.VertexMetadata;
 import com.radixdlt.consensus.VertexStore;
 import com.radixdlt.consensus.View;
 import com.radixdlt.mempool.Mempool;
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
 import java.util.Collections;
 import org.junit.Test;
 
@@ -40,8 +40,8 @@ public class MempoolProposalGeneratorTest {
 	public void when_vertex_store_contains_vertices_with_no_atom__then_generate_proposal_should_still_work() {
 		Mempool mempool = mock(Mempool.class);
 		Atom atom = mock(Atom.class);
-		SimpleRadixEngineAtom reAtom = mock(SimpleRadixEngineAtom.class);
-		when(reAtom.getAtom()).thenReturn(atom);
+		LedgerAtom reAtom = mock(LedgerAtom.class);
+		when(reAtom.getRaw()).thenReturn(atom);
 		when(mempool.getAtoms(anyInt(), anySet())).thenReturn(Collections.singletonList(reAtom));
 
 		VertexStore vertexStore = mock(VertexStore.class);

--- a/radixdlt/src/test/java/com/radixdlt/consensus/liveness/MempoolProposalGeneratorTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/liveness/MempoolProposalGeneratorTest.java
@@ -31,6 +31,7 @@ import com.radixdlt.consensus.VertexMetadata;
 import com.radixdlt.consensus.VertexStore;
 import com.radixdlt.consensus.View;
 import com.radixdlt.mempool.Mempool;
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 import java.util.Collections;
 import org.junit.Test;
 
@@ -39,7 +40,9 @@ public class MempoolProposalGeneratorTest {
 	public void when_vertex_store_contains_vertices_with_no_atom__then_generate_proposal_should_still_work() {
 		Mempool mempool = mock(Mempool.class);
 		Atom atom = mock(Atom.class);
-		when(mempool.getAtoms(anyInt(), anySet())).thenReturn(Collections.singletonList(atom));
+		SimpleRadixEngineAtom reAtom = mock(SimpleRadixEngineAtom.class);
+		when(reAtom.getAtom()).thenReturn(atom);
+		when(mempool.getAtoms(anyInt(), anySet())).thenReturn(Collections.singletonList(reAtom));
 
 		VertexStore vertexStore = mock(VertexStore.class);
 		QuorumCertificate qc = mock(QuorumCertificate.class);
@@ -51,6 +54,6 @@ public class MempoolProposalGeneratorTest {
 
 		MempoolProposalGenerator proposalGenerator = new MempoolProposalGenerator(vertexStore, mempool);
 		Vertex proposal = proposalGenerator.generateProposal(View.of(1));
-		assertThat(proposal.getAtom()).isEqualTo(atom);
+		assertThat(proposal.getRawAtom()).isEqualTo(atom);
 	}
 }

--- a/radixdlt/src/test/java/com/radixdlt/consensus/liveness/MempoolProposalGeneratorTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/liveness/MempoolProposalGeneratorTest.java
@@ -54,6 +54,6 @@ public class MempoolProposalGeneratorTest {
 
 		MempoolProposalGenerator proposalGenerator = new MempoolProposalGenerator(vertexStore, mempool);
 		Vertex proposal = proposalGenerator.generateProposal(View.of(1));
-		assertThat(proposal.getRawAtom()).isEqualTo(atom);
+		assertThat(proposal.getAtom()).isEqualTo(reAtom);
 	}
 }

--- a/radixdlt/src/test/java/com/radixdlt/mempool/LocalMempoolTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/mempool/LocalMempoolTest.java
@@ -17,6 +17,7 @@
 
 package com.radixdlt.mempool;
 
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 import java.util.List;
 
 import org.junit.Before;
@@ -28,7 +29,6 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.radixdlt.identifiers.AID;
-import com.radixdlt.atommodel.Atom;
 import com.radixdlt.properties.RuntimeProperties;
 import com.radixdlt.utils.Ints;
 
@@ -67,7 +67,7 @@ public class LocalMempoolTest {
 	@Test(expected = MempoolDuplicateException.class)
 	public void when_adding_atom_with_same_aid__then_exception_is_thrown()
 		throws MempoolFullException, MempoolDuplicateException {
-		Atom atom = mock(Atom.class);
+		SimpleRadixEngineAtom atom = mock(SimpleRadixEngineAtom.class);
 		when(atom.getAID()).thenReturn(AID.ZERO);
 
 		this.mempool.addAtom(atom);
@@ -80,7 +80,7 @@ public class LocalMempoolTest {
 		throws MempoolFullException, MempoolDuplicateException {
 		this.mempool.addAtom(makeAtom(1));
 		this.mempool.addAtom(makeAtom(2));
-		Atom badAtom = makeAtom(3);
+		SimpleRadixEngineAtom badAtom = makeAtom(3);
 		try {
 			this.mempool.addAtom(badAtom);
 			fail();
@@ -92,7 +92,7 @@ public class LocalMempoolTest {
 	@Test
 	public void when_committed_atom_is_removed__then_mempool_size_decreases()
 		throws MempoolFullException, MempoolDuplicateException {
-		Atom atom = makeAtom(1234);
+		SimpleRadixEngineAtom atom = makeAtom(1234);
 		this.mempool.addAtom(atom);
 		assertEquals(1, this.mempool.atomCount());
 		this.mempool.removeCommittedAtom(atom.getAID());
@@ -102,7 +102,7 @@ public class LocalMempoolTest {
 	@Test
 	public void when_rejected_atom_is_removed__then_mempool_size_decreases()
 		throws MempoolFullException, MempoolDuplicateException {
-		Atom atom = makeAtom(1234);
+		SimpleRadixEngineAtom atom = makeAtom(1234);
 		this.mempool.addAtom(atom);
 		assertEquals(1, this.mempool.atomCount());
 		this.mempool.removeRejectedAtom(atom.getAID());
@@ -112,11 +112,11 @@ public class LocalMempoolTest {
 	@Test
 	public void when_an_atom_is_requested__then_mempool_returns_and_retains_atoms()
 		throws MempoolFullException, MempoolDuplicateException {
-		Atom atom = makeAtom(1234);
+		SimpleRadixEngineAtom atom = makeAtom(1234);
 		this.mempool.addAtom(atom);
 		assertEquals(1, this.mempool.atomCount()); // precondition
 
-		List<Atom> atoms = this.mempool.getAtoms(1, Sets.newHashSet());
+		List<SimpleRadixEngineAtom> atoms = this.mempool.getAtoms(1, Sets.newHashSet());
 		assertEquals(1, atoms.size());
 		assertSame(atom, atoms.get(0));
 		assertEquals(1, this.mempool.atomCount()); // postcondition
@@ -125,11 +125,11 @@ public class LocalMempoolTest {
 	@Test
 	public void when_too_many_atoms_requested__then_mempool_returns_fewer_atoms()
 		throws MempoolFullException, MempoolDuplicateException {
-		Atom atom = makeAtom(1234);
+		SimpleRadixEngineAtom atom = makeAtom(1234);
 		this.mempool.addAtom(atom);
 		assertEquals(1, this.mempool.atomCount()); // precondition
 
-		List<Atom> atoms = this.mempool.getAtoms(2, Sets.newHashSet());
+		List<SimpleRadixEngineAtom> atoms = this.mempool.getAtoms(2, Sets.newHashSet());
 		assertEquals(1, atoms.size());
 		assertSame(atom, atoms.get(0));
 		assertEquals(1, this.mempool.atomCount()); // postcondition
@@ -139,7 +139,7 @@ public class LocalMempoolTest {
 	public void when_atoms_requested_from_empty_mempool__then_mempool_returns_empty_list() {
 		assertEquals(0, this.mempool.atomCount()); // precondition
 
-		List<Atom> atoms = this.mempool.getAtoms(1, Sets.newHashSet());
+		List<SimpleRadixEngineAtom> atoms = this.mempool.getAtoms(1, Sets.newHashSet());
 		assertTrue(atoms.isEmpty());
 		assertEquals(0, this.mempool.atomCount()); // postcondition
 	}
@@ -147,11 +147,11 @@ public class LocalMempoolTest {
 	@Test
 	public void when_an_atom_is_requested__then_mempool_excludes_atoms()
 		throws MempoolFullException, MempoolDuplicateException {
-		Atom atom = makeAtom(1234);
+		SimpleRadixEngineAtom atom = makeAtom(1234);
 		this.mempool.addAtom(atom);
 		assertEquals(1, this.mempool.atomCount()); // precondition
 
-		List<Atom> atoms = this.mempool.getAtoms(1, Sets.newHashSet(atom.getAID()));
+		List<SimpleRadixEngineAtom> atoms = this.mempool.getAtoms(1, Sets.newHashSet(atom.getAID()));
 		assertTrue(atoms.isEmpty());
 		assertEquals(1, this.mempool.atomCount()); // postcondition
 	}
@@ -179,8 +179,8 @@ public class LocalMempoolTest {
 		return AID.from(temp);
 	}
 
-	private static Atom makeAtom(int n) {
-		Atom atom = mock(Atom.class);
+	private static SimpleRadixEngineAtom makeAtom(int n) {
+		SimpleRadixEngineAtom atom = mock(SimpleRadixEngineAtom.class);
 		when(atom.getAID()).thenReturn(makeAID(n));
 		return atom;
 	}

--- a/radixdlt/src/test/java/com/radixdlt/mempool/LocalMempoolTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/mempool/LocalMempoolTest.java
@@ -17,7 +17,7 @@
 
 package com.radixdlt.mempool;
 
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
 import java.util.List;
 
 import org.junit.Before;
@@ -67,7 +67,7 @@ public class LocalMempoolTest {
 	@Test(expected = MempoolDuplicateException.class)
 	public void when_adding_atom_with_same_aid__then_exception_is_thrown()
 		throws MempoolFullException, MempoolDuplicateException {
-		SimpleRadixEngineAtom atom = mock(SimpleRadixEngineAtom.class);
+		LedgerAtom atom = mock(LedgerAtom.class);
 		when(atom.getAID()).thenReturn(AID.ZERO);
 
 		this.mempool.addAtom(atom);
@@ -80,7 +80,7 @@ public class LocalMempoolTest {
 		throws MempoolFullException, MempoolDuplicateException {
 		this.mempool.addAtom(makeAtom(1));
 		this.mempool.addAtom(makeAtom(2));
-		SimpleRadixEngineAtom badAtom = makeAtom(3);
+		LedgerAtom badAtom = makeAtom(3);
 		try {
 			this.mempool.addAtom(badAtom);
 			fail();
@@ -92,7 +92,7 @@ public class LocalMempoolTest {
 	@Test
 	public void when_committed_atom_is_removed__then_mempool_size_decreases()
 		throws MempoolFullException, MempoolDuplicateException {
-		SimpleRadixEngineAtom atom = makeAtom(1234);
+		LedgerAtom atom = makeAtom(1234);
 		this.mempool.addAtom(atom);
 		assertEquals(1, this.mempool.atomCount());
 		this.mempool.removeCommittedAtom(atom.getAID());
@@ -102,7 +102,7 @@ public class LocalMempoolTest {
 	@Test
 	public void when_rejected_atom_is_removed__then_mempool_size_decreases()
 		throws MempoolFullException, MempoolDuplicateException {
-		SimpleRadixEngineAtom atom = makeAtom(1234);
+		LedgerAtom atom = makeAtom(1234);
 		this.mempool.addAtom(atom);
 		assertEquals(1, this.mempool.atomCount());
 		this.mempool.removeRejectedAtom(atom.getAID());
@@ -112,11 +112,11 @@ public class LocalMempoolTest {
 	@Test
 	public void when_an_atom_is_requested__then_mempool_returns_and_retains_atoms()
 		throws MempoolFullException, MempoolDuplicateException {
-		SimpleRadixEngineAtom atom = makeAtom(1234);
+		LedgerAtom atom = makeAtom(1234);
 		this.mempool.addAtom(atom);
 		assertEquals(1, this.mempool.atomCount()); // precondition
 
-		List<SimpleRadixEngineAtom> atoms = this.mempool.getAtoms(1, Sets.newHashSet());
+		List<LedgerAtom> atoms = this.mempool.getAtoms(1, Sets.newHashSet());
 		assertEquals(1, atoms.size());
 		assertSame(atom, atoms.get(0));
 		assertEquals(1, this.mempool.atomCount()); // postcondition
@@ -125,11 +125,11 @@ public class LocalMempoolTest {
 	@Test
 	public void when_too_many_atoms_requested__then_mempool_returns_fewer_atoms()
 		throws MempoolFullException, MempoolDuplicateException {
-		SimpleRadixEngineAtom atom = makeAtom(1234);
+		LedgerAtom atom = makeAtom(1234);
 		this.mempool.addAtom(atom);
 		assertEquals(1, this.mempool.atomCount()); // precondition
 
-		List<SimpleRadixEngineAtom> atoms = this.mempool.getAtoms(2, Sets.newHashSet());
+		List<LedgerAtom> atoms = this.mempool.getAtoms(2, Sets.newHashSet());
 		assertEquals(1, atoms.size());
 		assertSame(atom, atoms.get(0));
 		assertEquals(1, this.mempool.atomCount()); // postcondition
@@ -139,7 +139,7 @@ public class LocalMempoolTest {
 	public void when_atoms_requested_from_empty_mempool__then_mempool_returns_empty_list() {
 		assertEquals(0, this.mempool.atomCount()); // precondition
 
-		List<SimpleRadixEngineAtom> atoms = this.mempool.getAtoms(1, Sets.newHashSet());
+		List<LedgerAtom> atoms = this.mempool.getAtoms(1, Sets.newHashSet());
 		assertTrue(atoms.isEmpty());
 		assertEquals(0, this.mempool.atomCount()); // postcondition
 	}
@@ -147,11 +147,11 @@ public class LocalMempoolTest {
 	@Test
 	public void when_an_atom_is_requested__then_mempool_excludes_atoms()
 		throws MempoolFullException, MempoolDuplicateException {
-		SimpleRadixEngineAtom atom = makeAtom(1234);
+		LedgerAtom atom = makeAtom(1234);
 		this.mempool.addAtom(atom);
 		assertEquals(1, this.mempool.atomCount()); // precondition
 
-		List<SimpleRadixEngineAtom> atoms = this.mempool.getAtoms(1, Sets.newHashSet(atom.getAID()));
+		List<LedgerAtom> atoms = this.mempool.getAtoms(1, Sets.newHashSet(atom.getAID()));
 		assertTrue(atoms.isEmpty());
 		assertEquals(1, this.mempool.atomCount()); // postcondition
 	}
@@ -179,8 +179,8 @@ public class LocalMempoolTest {
 		return AID.from(temp);
 	}
 
-	private static SimpleRadixEngineAtom makeAtom(int n) {
-		SimpleRadixEngineAtom atom = mock(SimpleRadixEngineAtom.class);
+	private static LedgerAtom makeAtom(int n) {
+		LedgerAtom atom = mock(LedgerAtom.class);
 		when(atom.getAID()).thenReturn(makeAID(n));
 		return atom;
 	}

--- a/radixdlt/src/test/java/com/radixdlt/mempool/MempoolReceiverTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/mempool/MempoolReceiverTest.java
@@ -17,14 +17,13 @@
 
 package com.radixdlt.mempool;
 
+import com.radixdlt.middleware2.LedgerAtom;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.radixdlt.atommodel.Atom;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -33,7 +32,7 @@ import io.reactivex.rxjava3.subjects.PublishSubject;
 
 public class MempoolReceiverTest {
 
-	private PublishSubject<Atom> atoms;
+	private PublishSubject<LedgerAtom> atoms;
 
 	private SubmissionControl submissionControl;
 	private MempoolReceiver mempoolReceiver;
@@ -81,7 +80,7 @@ public class MempoolReceiverTest {
 		this.mempoolReceiver.start();
 		assertTrue(this.mempoolReceiver.running());
 
-		Atom atom = mock(Atom.class);
+		LedgerAtom atom = mock(LedgerAtom.class);
 		atoms.onNext(atom);
 
 		// Wait for everything to get pushed through the pipeline

--- a/radixdlt/src/test/java/com/radixdlt/mempool/SharedMempoolTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/mempool/SharedMempoolTest.java
@@ -17,6 +17,8 @@
 
 package com.radixdlt.mempool;
 
+import com.google.inject.TypeLiteral;
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 import java.util.Set;
 
 import org.junit.Before;
@@ -29,7 +31,6 @@ import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.name.Names;
 import com.radixdlt.identifiers.AID;
-import com.radixdlt.atommodel.Atom;
 import com.radixdlt.counters.SystemCounters;
 import com.radixdlt.identifiers.EUID;
 import com.radixdlt.engine.RadixEngine;
@@ -46,10 +47,9 @@ public class SharedMempoolTest {
 
 	private LocalMempool localMempool;
 	private MempoolNetworkTx mempoolNetworkTx;
-	private RadixEngine radixEngine;
+	private RadixEngine<SimpleRadixEngineAtom> radixEngine;
 	private Serialization serialization;
 	private SystemCounters counters;
-
 	private Mempool sharedMempool;
 
 	@Before
@@ -67,7 +67,7 @@ public class SharedMempoolTest {
 				bind(LocalMempool.class).toInstance(localMempool);
 				bind(MempoolNetworkTx.class).toInstance(mempoolNetworkTx);
 				bind(EUID.class).annotatedWith(Names.named("self")).toInstance(self);
-				bind(RadixEngine.class).toInstance(radixEngine);
+				bind(new TypeLiteral<RadixEngine<SimpleRadixEngineAtom>>() { }).toInstance(radixEngine);
 				bind(Serialization.class).toInstance(serialization);
 				bind(SystemCounters.class).toInstance(counters);
 			}
@@ -80,7 +80,7 @@ public class SharedMempoolTest {
 	@Test
 	public void when_adding_atom__then_atom_is_added_and_sent()
 		throws MempoolFullException, MempoolDuplicateException {
-		Atom mockAtom = mock(Atom.class);
+		SimpleRadixEngineAtom mockAtom = mock(SimpleRadixEngineAtom.class);
 		when(mockAtom.getAID()).thenReturn(TEST_AID);
 		this.sharedMempool.addAtom(mockAtom);
 		verify(this.localMempool, times(1)).addAtom(any());

--- a/radixdlt/src/test/java/com/radixdlt/mempool/SharedMempoolTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/mempool/SharedMempoolTest.java
@@ -18,7 +18,7 @@
 package com.radixdlt.mempool;
 
 import com.google.inject.TypeLiteral;
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
 import java.util.Set;
 
 import org.junit.Before;
@@ -47,7 +47,7 @@ public class SharedMempoolTest {
 
 	private LocalMempool localMempool;
 	private MempoolNetworkTx mempoolNetworkTx;
-	private RadixEngine<SimpleRadixEngineAtom> radixEngine;
+	private RadixEngine<LedgerAtom> radixEngine;
 	private Serialization serialization;
 	private SystemCounters counters;
 	private Mempool sharedMempool;
@@ -67,7 +67,7 @@ public class SharedMempoolTest {
 				bind(LocalMempool.class).toInstance(localMempool);
 				bind(MempoolNetworkTx.class).toInstance(mempoolNetworkTx);
 				bind(EUID.class).annotatedWith(Names.named("self")).toInstance(self);
-				bind(new TypeLiteral<RadixEngine<SimpleRadixEngineAtom>>() { }).toInstance(radixEngine);
+				bind(new TypeLiteral<RadixEngine<LedgerAtom>>() { }).toInstance(radixEngine);
 				bind(Serialization.class).toInstance(serialization);
 				bind(SystemCounters.class).toInstance(counters);
 			}
@@ -80,7 +80,7 @@ public class SharedMempoolTest {
 	@Test
 	public void when_adding_atom__then_atom_is_added_and_sent()
 		throws MempoolFullException, MempoolDuplicateException {
-		SimpleRadixEngineAtom mockAtom = mock(SimpleRadixEngineAtom.class);
+		LedgerAtom mockAtom = mock(LedgerAtom.class);
 		when(mockAtom.getAID()).thenReturn(TEST_AID);
 		this.sharedMempool.addAtom(mockAtom);
 		verify(this.localMempool, times(1)).addAtom(any());

--- a/radixdlt/src/test/java/com/radixdlt/mempool/SubmissionControlImplTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/mempool/SubmissionControlImplTest.java
@@ -19,8 +19,10 @@ package com.radixdlt.mempool;
 
 import com.radixdlt.engine.RadixEngineException;
 import com.radixdlt.middleware2.LedgerAtom;
+import com.radixdlt.middleware2.converters.AtomConversionException;
 import com.radixdlt.middleware2.converters.AtomToLedgerAtomConverter;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,7 +40,7 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 import static org.hamcrest.Matchers.*;
 
-public class SubmissionControlTest {
+public class SubmissionControlImplTest {
 
 	private Mempool mempool;
 	private RadixEngine<LedgerAtom> radixEngine;
@@ -84,6 +86,22 @@ public class SubmissionControlTest {
 	}
 
 	@Test
+	public void when_conversion_fails_then_exception_is_broadcasted_and_atom_is_not_added_to_mempool() throws Exception {
+		doNothing().when(this.events).broadcast(any());
+
+		JSONObject atomJson = mock(JSONObject.class);
+		Atom atom = mock(Atom.class);
+		AID aid = mock(AID.class);
+		when(atom.getAID()).thenReturn(aid);
+		doReturn(atom).when(this.serialization).fromJsonObject(eq(atomJson), eq(Atom.class));
+		when(converter.convert(eq(atom))).thenThrow(mock(AtomConversionException.class));
+		Consumer<LedgerAtom> callback = mock(Consumer.class);
+		this.submissionControl.submitAtom(atomJson, callback);
+		verify(this.events, times(1)).broadcast(argThat(AtomExceptionEvent.class::isInstance));
+		verify(this.mempool, never()).addAtom(any());
+	}
+
+	@Test
 	public void if_deserialisation_fails__then_callback_is_not_called() throws Exception {
 		doThrow(new IllegalArgumentException()).when(this.serialization).fromJsonObject(any(), any());
 
@@ -108,16 +126,14 @@ public class SubmissionControlTest {
 		doReturn(atomMock).when(this.serialization).fromJsonObject(any(), any());
 		doNothing().when(this.mempool).addAtom(any());
 
-		AtomicBoolean called = new AtomicBoolean(false);
 
 		LedgerAtom ledgerAtom = mock(LedgerAtom.class);
 		when(ledgerAtom.getAID()).thenReturn(AID.ZERO);
 		when(converter.convert(eq(atomMock))).thenReturn(ledgerAtom);
-		AID result = this.submissionControl.submitAtom(throwingMock(JSONObject.class), a -> called.set(true));
+		Consumer<LedgerAtom> callback = mock(Consumer.class);
+		this.submissionControl.submitAtom(throwingMock(JSONObject.class), callback);
 
-		assertSame(AID.ZERO, result);
-
-		assertThat(called.get(), is(true));
+		verify(callback, times(1)).accept(argThat(a -> a.getAID().equals(AID.ZERO)));
 		verify(this.events, never()).broadcast(any());
 		verify(this.mempool, times(1)).addAtom(any());
 	}

--- a/radixdlt/src/test/java/com/radixdlt/mempool/SubmissionControlTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/mempool/SubmissionControlTest.java
@@ -17,8 +17,8 @@
 
 package com.radixdlt.mempool;
 
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
-import com.radixdlt.middleware2.converters.AtomToRadixEngineAtomConverter;
+import com.radixdlt.middleware2.LedgerAtom;
+import com.radixdlt.middleware2.converters.AtomToLedgerAtomConverter;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.json.JSONObject;
@@ -42,11 +42,11 @@ import static org.hamcrest.Matchers.*;
 public class SubmissionControlTest {
 
 	private Mempool mempool;
-	private RadixEngine<SimpleRadixEngineAtom> radixEngine;
+	private RadixEngine<LedgerAtom> radixEngine;
 	private Serialization serialization;
 	private Events events;
 	private SubmissionControlImpl submissionControl;
-	private AtomToRadixEngineAtomConverter converter;
+	private AtomToLedgerAtomConverter converter;
 
 	@Before
 	public void setUp() {
@@ -54,7 +54,7 @@ public class SubmissionControlTest {
 		this.radixEngine = throwingMock(RadixEngine.class);
 		this.serialization = throwingMock(Serialization.class);
 		this.events = throwingMock(Events.class);
-		this.converter = mock(AtomToRadixEngineAtomConverter.class);
+		this.converter = mock(AtomToLedgerAtomConverter.class);
 		this.submissionControl = new SubmissionControlImpl(this.mempool, this.radixEngine, this.serialization, this.events, this.converter);
 	}
 
@@ -70,7 +70,7 @@ public class SubmissionControlTest {
 
 		Atom atom = throwingMock(Atom.class);
 		doReturn(AID.ZERO).when(atom).getAID();
-		SimpleRadixEngineAtom reAtom = mock(SimpleRadixEngineAtom.class);
+		LedgerAtom reAtom = mock(LedgerAtom.class);
 		when(converter.convert(eq(atom))).thenReturn(reAtom);
 
 		this.submissionControl.submitAtom(atom);
@@ -85,7 +85,7 @@ public class SubmissionControlTest {
 		doNothing().when(this.mempool).addAtom(any());
 
 		Atom atom = throwingMock(Atom.class);
-		SimpleRadixEngineAtom reAtom = mock(SimpleRadixEngineAtom.class);
+		LedgerAtom reAtom = mock(LedgerAtom.class);
 		when(converter.convert(eq(atom))).thenReturn(reAtom);
 		this.submissionControl.submitAtom(atom);
 

--- a/radixdlt/src/test/java/com/radixdlt/mempool/SubmissionControlTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/mempool/SubmissionControlTest.java
@@ -68,11 +68,7 @@ public class SubmissionControlTest {
 		doReturn(error).when(this.radixEngine).staticCheck(any());
 		doNothing().when(this.events).broadcast(any());
 
-		Atom atom = throwingMock(Atom.class);
-		doReturn(AID.ZERO).when(atom).getAID();
-		LedgerAtom reAtom = mock(LedgerAtom.class);
-		when(converter.convert(eq(atom))).thenReturn(reAtom);
-
+		LedgerAtom atom = mock(LedgerAtom.class);
 		this.submissionControl.submitAtom(atom);
 
 		verify(this.events, times(1)).broadcast(ArgumentMatchers.any(AtomExceptionEvent.class));
@@ -84,13 +80,11 @@ public class SubmissionControlTest {
 		doReturn(Optional.empty()).when(this.radixEngine).staticCheck(any());
 		doNothing().when(this.mempool).addAtom(any());
 
-		Atom atom = throwingMock(Atom.class);
-		LedgerAtom reAtom = mock(LedgerAtom.class);
-		when(converter.convert(eq(atom))).thenReturn(reAtom);
+		LedgerAtom atom = mock(LedgerAtom.class);
 		this.submissionControl.submitAtom(atom);
 
 		verify(this.events, never()).broadcast(any());
-		verify(this.mempool, times(1)).addAtom(eq(reAtom));
+		verify(this.mempool, times(1)).addAtom(eq(atom));
 	}
 
 	@Test
@@ -113,7 +107,7 @@ public class SubmissionControlTest {
 
 	@Test
 	public void after_json_deserialised__then_callback_is_called_and_aid_returned()
-		throws MempoolFullException, MempoolDuplicateException {
+		throws Exception {
 		doReturn(Optional.empty()).when(this.radixEngine).staticCheck(any());
 		Atom atomMock = throwingMock(Atom.class);
 		doReturn(AID.ZERO).when(atomMock).getAID();
@@ -122,6 +116,9 @@ public class SubmissionControlTest {
 
 		AtomicBoolean called = new AtomicBoolean(false);
 
+		LedgerAtom ledgerAtom = mock(LedgerAtom.class);
+		when(ledgerAtom.getAID()).thenReturn(AID.ZERO);
+		when(converter.convert(eq(atomMock))).thenReturn(ledgerAtom);
 		AID result = this.submissionControl.submitAtom(throwingMock(JSONObject.class), a -> called.set(true));
 
 		assertSame(AID.ZERO, result);

--- a/radixdlt/src/test/java/com/radixdlt/middleware2/LedgerAtomCheckerTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/middleware2/LedgerAtomCheckerTest.java
@@ -22,96 +22,109 @@ import com.google.common.collect.ImmutableMap;
 import com.radixdlt.constraintmachine.CMInstruction;
 import com.radixdlt.constraintmachine.CMMicroInstruction;
 import com.radixdlt.crypto.Hash;
+import com.radixdlt.identifiers.AID;
 import com.radixdlt.universe.Universe;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class LedgerAtomCheckerTest {
-	@Test
-	public void when_validating_atom_with_particles__result_has_no_error() {
-		Universe universe = mock(Universe.class);
+	private LedgerAtomChecker checker;
+	private Universe universe;
+	private PowFeeComputer powFeeComputer;
+	private Hash target;
+
+	@Before
+	public void setUp() {
+		this.universe = mock(Universe.class);
 		when(universe.getGenesis()).thenReturn(Collections.emptyList());
-		LedgerAtomChecker ledgerAtomChecker = new LedgerAtomChecker(
+		this.powFeeComputer = mock(PowFeeComputer.class);
+		this.target = mock(Hash.class);
+		this.checker = new LedgerAtomChecker(
 			() -> universe,
 			() -> 0,
-			true,
+			powFeeComputer,
+			target,
+			false,
 			30
 		);
+	}
+
+	@Test
+	public void when_validating_atom_with_particles__result_has_no_error() {
+		when(universe.getGenesis()).thenReturn(Collections.emptyList());
 		LedgerAtom ledgerAtom = mock(LedgerAtom.class);
 		CMInstruction cmInstruction = new CMInstruction(
 			ImmutableList.of(mock(CMMicroInstruction.class)), Hash.random(), ImmutableMap.of()
 		);
+		when(ledgerAtom.getAID()).thenReturn(mock(AID.class));
 		when(ledgerAtom.getCMInstruction()).thenReturn(cmInstruction);
-		when(ledgerAtom.getMetaData()).thenReturn(ImmutableMap.of("timestamp", "0"));
-
-		assertThat(ledgerAtomChecker.hook(ledgerAtom).isSuccess()).isTrue();
+		when(ledgerAtom.getMetaData()).thenReturn(
+			ImmutableMap.of(
+				"timestamp", "0",
+				"powNonce", "0"
+			)
+		);
+		Hash powSpent = mock(Hash.class);
+		when(powFeeComputer.computePowSpent(eq(ledgerAtom), eq(0L))).thenReturn(powSpent);
+		when(powSpent.compareTo(eq(target))).thenReturn(-1);
+		assertThat(checker.hook(ledgerAtom).isSuccess()).isTrue();
 	}
 
 	@Test
 	public void when_validating_atom_without_particles__result_has_error() {
-		Universe universe = mock(Universe.class);
-		when(universe.getGenesis()).thenReturn(Collections.emptyList());
-		LedgerAtomChecker ledgerAtomChecker = new LedgerAtomChecker(
-			() -> universe,
-			() -> 0,
-			true,
-			30
-		);
 		LedgerAtom ledgerAtom = mock(LedgerAtom.class);
 		CMInstruction cmInstruction = new CMInstruction(
 			ImmutableList.of(), Hash.random(), ImmutableMap.of()
 		);
+		when(ledgerAtom.getAID()).thenReturn(mock(AID.class));
 		when(ledgerAtom.getCMInstruction()).thenReturn(cmInstruction);
 		when(ledgerAtom.getMetaData()).thenReturn(ImmutableMap.of("timestamp", "0"));
 
-		assertThat(ledgerAtomChecker.hook(ledgerAtom).getErrorMessage())
+		assertThat(checker.hook(ledgerAtom).getErrorMessage())
 			.contains("instructions");
 	}
 
 	@Test
 	public void when_validating_atom_without_metadata__result_has_error() {
-		Universe universe = mock(Universe.class);
-		when(universe.getGenesis()).thenReturn(Collections.emptyList());
-		LedgerAtomChecker ledgerAtomChecker = new LedgerAtomChecker(
-			() -> universe,
-			() -> 0,
-			true,
-			30
-		);
 		LedgerAtom ledgerAtom = mock(LedgerAtom.class);
 		CMInstruction cmInstruction = new CMInstruction(
 			ImmutableList.of(mock(CMMicroInstruction.class)), Hash.random(), ImmutableMap.of()
 		);
+		when(ledgerAtom.getAID()).thenReturn(mock(AID.class));
 		when(ledgerAtom.getCMInstruction()).thenReturn(cmInstruction);
 		when(ledgerAtom.getMetaData()).thenReturn(ImmutableMap.of());
 
-		assertThat(ledgerAtomChecker.hook(ledgerAtom).getErrorMessage())
+		assertThat(checker.hook(ledgerAtom).getErrorMessage())
 			.contains("metadata does not contain");
 	}
 
 	@Test
 	public void when_validating_atom_with_bad_timestamp__result_has_error() {
-		Universe universe = mock(Universe.class);
-		when(universe.getGenesis()).thenReturn(Collections.emptyList());
-		LedgerAtomChecker ledgerAtomChecker = new LedgerAtomChecker(
-			() -> universe,
-			() -> 0,
-			true,
-			30
-		);
 		LedgerAtom ledgerAtom = mock(LedgerAtom.class);
 		CMInstruction cmInstruction = new CMInstruction(
 			ImmutableList.of(mock(CMMicroInstruction.class)), Hash.random(), ImmutableMap.of()
 		);
+		when(ledgerAtom.getAID()).thenReturn(mock(AID.class));
 		when(ledgerAtom.getCMInstruction()).thenReturn(cmInstruction);
-		when(ledgerAtom.getMetaData()).thenReturn(ImmutableMap.of("timestamp", "badinput"));
+		when(ledgerAtom.getMetaData()).thenReturn(
+			ImmutableMap.of(
+				"timestamp", "badinput",
+				"powNonce", "0"
+			)
+		);
+		Hash powFeeHash = mock(Hash.class);
+		when(ledgerAtom.getPowFeeHash()).thenReturn(powFeeHash);
+		when(powFeeComputer.computePowSpent(eq(ledgerAtom), eq(0L))).thenReturn(powFeeHash);
+		when(powFeeHash.compareTo(eq(target))).thenReturn(-1);
 
-		assertThat(ledgerAtomChecker.hook(ledgerAtom).getErrorMessage())
+		assertThat(checker.hook(ledgerAtom).getErrorMessage())
 			.contains("invalid timestamp");
 	}
 }

--- a/radixdlt/src/test/java/com/radixdlt/middleware2/LedgerAtomCheckerTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/middleware2/LedgerAtomCheckerTest.java
@@ -1,0 +1,117 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package com.radixdlt.middleware2;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.radixdlt.constraintmachine.CMInstruction;
+import com.radixdlt.constraintmachine.CMMicroInstruction;
+import com.radixdlt.crypto.Hash;
+import com.radixdlt.universe.Universe;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class LedgerAtomCheckerTest {
+	@Test
+	public void when_validating_atom_with_particles__result_has_no_error() {
+		Universe universe = mock(Universe.class);
+		when(universe.getGenesis()).thenReturn(Collections.emptyList());
+		LedgerAtomChecker ledgerAtomChecker = new LedgerAtomChecker(
+			() -> universe,
+			() -> 0,
+			true,
+			30
+		);
+		LedgerAtom ledgerAtom = mock(LedgerAtom.class);
+		CMInstruction cmInstruction = new CMInstruction(
+			ImmutableList.of(mock(CMMicroInstruction.class)), Hash.random(), ImmutableMap.of()
+		);
+		when(ledgerAtom.getCMInstruction()).thenReturn(cmInstruction);
+		when(ledgerAtom.getMetaData()).thenReturn(ImmutableMap.of("timestamp", "0"));
+
+		assertThat(ledgerAtomChecker.hook(ledgerAtom).isSuccess()).isTrue();
+	}
+
+	@Test
+	public void when_validating_atom_without_particles__result_has_error() {
+		Universe universe = mock(Universe.class);
+		when(universe.getGenesis()).thenReturn(Collections.emptyList());
+		LedgerAtomChecker ledgerAtomChecker = new LedgerAtomChecker(
+			() -> universe,
+			() -> 0,
+			true,
+			30
+		);
+		LedgerAtom ledgerAtom = mock(LedgerAtom.class);
+		CMInstruction cmInstruction = new CMInstruction(
+			ImmutableList.of(), Hash.random(), ImmutableMap.of()
+		);
+		when(ledgerAtom.getCMInstruction()).thenReturn(cmInstruction);
+		when(ledgerAtom.getMetaData()).thenReturn(ImmutableMap.of("timestamp", "0"));
+
+		assertThat(ledgerAtomChecker.hook(ledgerAtom).getErrorMessage())
+			.contains("instructions");
+	}
+
+	@Test
+	public void when_validating_atom_without_metadata__result_has_error() {
+		Universe universe = mock(Universe.class);
+		when(universe.getGenesis()).thenReturn(Collections.emptyList());
+		LedgerAtomChecker ledgerAtomChecker = new LedgerAtomChecker(
+			() -> universe,
+			() -> 0,
+			true,
+			30
+		);
+		LedgerAtom ledgerAtom = mock(LedgerAtom.class);
+		CMInstruction cmInstruction = new CMInstruction(
+			ImmutableList.of(mock(CMMicroInstruction.class)), Hash.random(), ImmutableMap.of()
+		);
+		when(ledgerAtom.getCMInstruction()).thenReturn(cmInstruction);
+		when(ledgerAtom.getMetaData()).thenReturn(ImmutableMap.of());
+
+		assertThat(ledgerAtomChecker.hook(ledgerAtom).getErrorMessage())
+			.contains("metadata does not contain");
+	}
+
+	@Test
+	public void when_validating_atom_with_bad_timestamp__result_has_error() {
+		Universe universe = mock(Universe.class);
+		when(universe.getGenesis()).thenReturn(Collections.emptyList());
+		LedgerAtomChecker ledgerAtomChecker = new LedgerAtomChecker(
+			() -> universe,
+			() -> 0,
+			true,
+			30
+		);
+		LedgerAtom ledgerAtom = mock(LedgerAtom.class);
+		CMInstruction cmInstruction = new CMInstruction(
+			ImmutableList.of(mock(CMMicroInstruction.class)), Hash.random(), ImmutableMap.of()
+		);
+		when(ledgerAtom.getCMInstruction()).thenReturn(cmInstruction);
+		when(ledgerAtom.getMetaData()).thenReturn(ImmutableMap.of("timestamp", "badinput"));
+
+		assertThat(ledgerAtomChecker.hook(ledgerAtom).getErrorMessage())
+			.contains("invalid timestamp");
+	}
+}

--- a/radixdlt/src/test/java/com/radixdlt/middleware2/LedgerAtomTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/middleware2/LedgerAtomTest.java
@@ -15,11 +15,15 @@
  * language governing permissions and limitations under the License.
  */
 
-package com.radixdlt.middleware2.converters;
+package com.radixdlt.middleware2;
 
-import com.radixdlt.atommodel.Atom;
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
 
-public interface AtomToRadixEngineAtomConverter {
-	SimpleRadixEngineAtom convert(Atom atom) throws AtomConversionException;
+public class LedgerAtomTest {
+	@Test
+	public void equalsContract() {
+		EqualsVerifier.forClass(LedgerAtom.class)
+			.verify();
+	}
 }

--- a/radixdlt/src/test/java/com/radixdlt/middleware2/converters/AtomToBinaryConverterTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/middleware2/converters/AtomToBinaryConverterTest.java
@@ -28,9 +28,8 @@ import com.radixdlt.identifiers.EUID;
 import com.radixdlt.crypto.ECKeyPair;
 import com.radixdlt.crypto.ECDSASignature;
 import com.radixdlt.middleware.ParticleGroup;
-import com.radixdlt.middleware.RadixEngineUtils;
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
 import com.radixdlt.middleware.SpunParticle;
+import com.radixdlt.middleware2.LedgerAtom;
 import org.junit.Test;
 
 import java.math.BigInteger;
@@ -55,11 +54,11 @@ public class AtomToBinaryConverterTest {
 			ImmutableMap.of("timestamp", "0")
 		);
 
-		SimpleRadixEngineAtom reAtom = RadixEngineUtils.toCMAtom(atom);
+		LedgerAtom reAtom = LedgerAtom.convert(atom);
 
 		byte[] serializedAtom = atomToBinaryConverter.toLedgerEntryContent(reAtom);
-		SimpleRadixEngineAtom deserializedAtom = atomToBinaryConverter.toAtom(serializedAtom);
-		assertEquals(reAtom.getAtom(), deserializedAtom.getAtom());
+		LedgerAtom deserializedAtom = atomToBinaryConverter.toAtom(serializedAtom);
+		assertEquals(reAtom, deserializedAtom);
 	}
 
 }

--- a/radixdlt/src/test/java/com/radixdlt/middleware2/converters/AtomToBinaryConverterTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/middleware2/converters/AtomToBinaryConverterTest.java
@@ -54,11 +54,11 @@ public class AtomToBinaryConverterTest {
 			ImmutableMap.of("timestamp", "0")
 		);
 
-		LedgerAtom reAtom = LedgerAtom.convert(atom);
+		LedgerAtom ledgerAtom = LedgerAtom.convertFromApiAtom(atom);
 
-		byte[] serializedAtom = atomToBinaryConverter.toLedgerEntryContent(reAtom);
+		byte[] serializedAtom = atomToBinaryConverter.toLedgerEntryContent(ledgerAtom);
 		LedgerAtom deserializedAtom = atomToBinaryConverter.toAtom(serializedAtom);
-		assertEquals(reAtom, deserializedAtom);
+		assertEquals(ledgerAtom, deserializedAtom);
 	}
 
 }

--- a/radixdlt/src/test/java/com/radixdlt/middleware2/converters/AtomToBinaryConverterTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/middleware2/converters/AtomToBinaryConverterTest.java
@@ -28,6 +28,8 @@ import com.radixdlt.identifiers.EUID;
 import com.radixdlt.crypto.ECKeyPair;
 import com.radixdlt.crypto.ECDSASignature;
 import com.radixdlt.middleware.ParticleGroup;
+import com.radixdlt.middleware.RadixEngineUtils;
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 import com.radixdlt.middleware.SpunParticle;
 import org.junit.Test;
 
@@ -39,7 +41,7 @@ public class AtomToBinaryConverterTest {
 	private AtomToBinaryConverter atomToBinaryConverter = new AtomToBinaryConverter(DefaultSerialization.getInstance());
 
 	@Test
-	public void test_atom_content_transformation_to_byte_array_and_back() {
+	public void test_atom_content_transformation_to_byte_array_and_back() throws Exception {
 		ECDSASignature ecSignature = new ECDSASignature(BigInteger.ONE, BigInteger.ONE);
 		ECKeyPair key = ECKeyPair.generateNew();
 		RadixAddress radixAddress = new RadixAddress((byte) 1, key.getPublicKey());
@@ -53,9 +55,11 @@ public class AtomToBinaryConverterTest {
 			ImmutableMap.of("timestamp", "0")
 		);
 
-		byte[] serializedAtom = atomToBinaryConverter.toLedgerEntryContent(atom);
-		Atom deserializedAtom = atomToBinaryConverter.toAtom(serializedAtom);
-		assertEquals(atom, deserializedAtom);
+		SimpleRadixEngineAtom reAtom = RadixEngineUtils.toCMAtom(atom);
+
+		byte[] serializedAtom = atomToBinaryConverter.toLedgerEntryContent(reAtom);
+		SimpleRadixEngineAtom deserializedAtom = atomToBinaryConverter.toAtom(serializedAtom);
+		assertEquals(reAtom.getAtom(), deserializedAtom.getAtom());
 	}
 
 }

--- a/radixdlt/src/test/java/com/radixdlt/middleware2/network/SimpleMempoolNetworkTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/middleware2/network/SimpleMempoolNetworkTest.java
@@ -17,7 +17,7 @@
 
 package com.radixdlt.middleware2.network;
 
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
@@ -56,9 +56,9 @@ public class SimpleMempoolNetworkTest {
 		MessageCentral messageCentral = mock(MessageCentral.class);
 		SimpleMempoolNetwork smn = new SimpleMempoolNetwork(system, universe, addressBook, messageCentral);
 
-		SimpleRadixEngineAtom reAtom = mock(SimpleRadixEngineAtom.class);
+		LedgerAtom reAtom = mock(LedgerAtom.class);
 		Atom rawAtom = mock(Atom.class);
-		when(reAtom.getAtom()).thenReturn(rawAtom);
+		when(reAtom.getRaw()).thenReturn(rawAtom);
 		smn.sendMempoolSubmission(reAtom);
 
 		verify(messageCentral, times(1)).send(any(), any());

--- a/radixdlt/src/test/java/com/radixdlt/middleware2/network/SimpleMempoolNetworkTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/middleware2/network/SimpleMempoolNetworkTest.java
@@ -24,7 +24,6 @@ import java.util.stream.Stream;
 import org.junit.Test;
 import org.radix.universe.system.LocalSystem;
 
-import com.radixdlt.atommodel.Atom;
 import com.radixdlt.identifiers.EUID;
 import com.radixdlt.mempool.messages.MempoolAtomAddedMessage;
 import com.radixdlt.network.addressbook.AddressBook;
@@ -56,10 +55,8 @@ public class SimpleMempoolNetworkTest {
 		MessageCentral messageCentral = mock(MessageCentral.class);
 		SimpleMempoolNetwork smn = new SimpleMempoolNetwork(system, universe, addressBook, messageCentral);
 
-		LedgerAtom reAtom = mock(LedgerAtom.class);
-		Atom rawAtom = mock(Atom.class);
-		when(reAtom.getRaw()).thenReturn(rawAtom);
-		smn.sendMempoolSubmission(reAtom);
+		LedgerAtom atom = mock(LedgerAtom.class);
+		smn.sendMempoolSubmission(atom);
 
 		verify(messageCentral, times(1)).send(any(), any());
 	}
@@ -82,12 +79,12 @@ public class SimpleMempoolNetworkTest {
 		assertNotNull(callbackRef.get());
 		MessageListener<MempoolAtomAddedMessage> callback = callbackRef.get();
 
-		TestObserver<Atom> obs = TestObserver.create();
+		TestObserver<LedgerAtom> obs = TestObserver.create();
 		smn.atomMessages()
 			.subscribe(obs);
 
 		Peer peer = mock(Peer.class);
-		Atom atom = mock(Atom.class);
+		LedgerAtom atom = mock(LedgerAtom.class);
 		MempoolAtomAddedMessage message = mock(MempoolAtomAddedMessage.class);
 		when(message.atom()).thenReturn(atom);
 		callback.handleMessage(peer, message);

--- a/radixdlt/src/test/java/com/radixdlt/middleware2/network/SimpleMempoolNetworkTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/middleware2/network/SimpleMempoolNetworkTest.java
@@ -17,6 +17,7 @@
 
 package com.radixdlt.middleware2.network;
 
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
@@ -55,8 +56,10 @@ public class SimpleMempoolNetworkTest {
 		MessageCentral messageCentral = mock(MessageCentral.class);
 		SimpleMempoolNetwork smn = new SimpleMempoolNetwork(system, universe, addressBook, messageCentral);
 
-		Atom atom = mock(Atom.class);
-		smn.sendMempoolSubmission(atom);
+		SimpleRadixEngineAtom reAtom = mock(SimpleRadixEngineAtom.class);
+		Atom rawAtom = mock(Atom.class);
+		when(reAtom.getAtom()).thenReturn(rawAtom);
+		smn.sendMempoolSubmission(reAtom);
 
 		verify(messageCentral, times(1)).send(any(), any());
 	}

--- a/radixdlt/src/test/java/org/radix/api/jsonrpc/SubmitAtomAndSubscribeEpicTest.java
+++ b/radixdlt/src/test/java/org/radix/api/jsonrpc/SubmitAtomAndSubscribeEpicTest.java
@@ -18,7 +18,7 @@
 package org.radix.api.jsonrpc;
 
 import com.radixdlt.identifiers.AID;
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
 import org.everit.json.schema.Schema;
 import org.json.JSONObject;
 import org.junit.Test;
@@ -54,7 +54,7 @@ public class SubmitAtomAndSubscribeEpicTest {
 		when(action.getJSONObject("params")).thenReturn(params);
 		when(params.getJSONObject("atom")).thenReturn(jsonAtom);
 
-		SimpleRadixEngineAtom atom = mock(SimpleRadixEngineAtom.class);
+		LedgerAtom atom = mock(LedgerAtom.class);
 
 		doAnswer((invocation) -> {
 			((SingleAtomListener) invocation.getArguments()[1]).onError(AID.ZERO, new ConstraintMachineValidationException(atom, "", DataPointer.ofAtom()));

--- a/radixdlt/src/test/java/org/radix/api/jsonrpc/SubmitAtomAndSubscribeEpicTest.java
+++ b/radixdlt/src/test/java/org/radix/api/jsonrpc/SubmitAtomAndSubscribeEpicTest.java
@@ -18,7 +18,7 @@
 package org.radix.api.jsonrpc;
 
 import com.radixdlt.identifiers.AID;
-import com.radixdlt.atommodel.Atom;
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 import org.everit.json.schema.Schema;
 import org.json.JSONObject;
 import org.junit.Test;
@@ -27,13 +27,11 @@ import org.radix.api.services.AtomsService;
 import org.radix.api.services.SingleAtomListener;
 import com.radixdlt.constraintmachine.DataPointer;
 import org.radix.validation.ConstraintMachineValidationException;
-import com.radixdlt.serialization.Serialization;
 
 import java.util.function.Consumer;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -49,7 +47,6 @@ public class SubmitAtomAndSubscribeEpicTest {
 	public void testAtomValidationError() {
 		AtomsService atomsService = mock(AtomsService.class);
 		Schema schema = mock(Schema.class);
-		Serialization serializer = mock(Serialization.class);
 		Consumer<JSONObject> callback = mock(ConsumerJSONObject.class);
 		JSONObject action = mock(JSONObject.class);
 		JSONObject params = mock(JSONObject.class);
@@ -57,9 +54,7 @@ public class SubmitAtomAndSubscribeEpicTest {
 		when(action.getJSONObject("params")).thenReturn(params);
 		when(params.getJSONObject("atom")).thenReturn(jsonAtom);
 
-		Atom atom = mock(Atom.class);
-
-		when(serializer.fromJsonObject(eq(jsonAtom), eq(Atom.class))).thenReturn(atom);
+		SimpleRadixEngineAtom atom = mock(SimpleRadixEngineAtom.class);
 
 		doAnswer((invocation) -> {
 			((SingleAtomListener) invocation.getArguments()[1]).onError(AID.ZERO, new ConstraintMachineValidationException(atom, "", DataPointer.ofAtom()));

--- a/radixdlt/src/test/java/org/radix/serialization/LedgerAtomSerializeTest.java
+++ b/radixdlt/src/test/java/org/radix/serialization/LedgerAtomSerializeTest.java
@@ -17,15 +17,12 @@
 
 package org.radix.serialization;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-
 import com.radixdlt.atommodel.Atom;
 import com.radixdlt.atommodel.message.MessageParticle;
 import com.radixdlt.constraintmachine.Spin;
 import com.radixdlt.identifiers.RadixAddress;
 import com.radixdlt.middleware2.LedgerAtom;
 import com.radixdlt.middleware2.LedgerAtom.LedgerAtomConversionException;
-import org.junit.Test;
 
 public class LedgerAtomSerializeTest extends SerializeObject<LedgerAtom> {
 	public LedgerAtomSerializeTest() {

--- a/radixdlt/src/test/java/org/radix/serialization/LedgerAtomSerializeTest.java
+++ b/radixdlt/src/test/java/org/radix/serialization/LedgerAtomSerializeTest.java
@@ -1,0 +1,58 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package org.radix.serialization;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.radixdlt.atommodel.Atom;
+import com.radixdlt.atommodel.message.MessageParticle;
+import com.radixdlt.constraintmachine.Spin;
+import com.radixdlt.identifiers.RadixAddress;
+import com.radixdlt.middleware2.LedgerAtom;
+import com.radixdlt.middleware2.LedgerAtom.LedgerAtomConversionException;
+import org.junit.Test;
+
+public class LedgerAtomSerializeTest extends SerializeObject<LedgerAtom> {
+	public LedgerAtomSerializeTest() {
+		super(LedgerAtom.class, LedgerAtomSerializeTest::get);
+	}
+
+	private static Atom createApiAtom() {
+		RadixAddress address = RadixAddress.from("JH1P8f3znbyrDj8F4RWpix7hRkgxqHjdW2fNnKpR3v6ufXnknor");
+		Atom atom = new Atom();
+		// add a particle to ensure atom is valid and has at least one shard
+		atom.addParticleGroupWith(new MessageParticle(address, address, "Hello".getBytes()), Spin.UP);
+		return atom;
+	}
+
+	private static LedgerAtom get(Atom atom) {
+		final LedgerAtom ledgerAtom;
+		try {
+			ledgerAtom = LedgerAtom.convertFromApiAtom(atom);
+		} catch (LedgerAtomConversionException e) {
+			throw new IllegalStateException();
+		}
+
+		return ledgerAtom;
+	}
+
+	private static LedgerAtom get() {
+		return get(createApiAtom());
+	}
+
+}

--- a/radixdlt/src/test/java/org/radix/serialization/MempoolAtomAddedMessageSerializeTest.java
+++ b/radixdlt/src/test/java/org/radix/serialization/MempoolAtomAddedMessageSerializeTest.java
@@ -18,7 +18,13 @@
 package org.radix.serialization;
 
 import com.radixdlt.atommodel.Atom;
+import com.radixdlt.atommodel.message.MessageParticle;
+import com.radixdlt.constraintmachine.Particle;
+import com.radixdlt.constraintmachine.Spin;
+import com.radixdlt.identifiers.RadixAddress;
 import com.radixdlt.mempool.messages.MempoolAtomAddedMessage;
+import com.radixdlt.middleware2.LedgerAtom;
+import com.radixdlt.middleware2.LedgerAtom.LedgerAtomConversionException;
 
 public class MempoolAtomAddedMessageSerializeTest extends SerializeMessageObject<MempoolAtomAddedMessage> {
 	public MempoolAtomAddedMessageSerializeTest() {
@@ -27,6 +33,14 @@ public class MempoolAtomAddedMessageSerializeTest extends SerializeMessageObject
 
 	private static MempoolAtomAddedMessage get() {
 		Atom atom = new Atom();
-		return new MempoolAtomAddedMessage(1, atom);
+		RadixAddress address = RadixAddress.from("JH1P8f3znbyrDj8F4RWpix7hRkgxqHjdW2fNnKpR3v6ufXnknor");
+		atom.addParticleGroupWith(new MessageParticle(address, address, "Hello".getBytes()), Spin.UP);
+		final LedgerAtom ledgerAtom;
+		try {
+			ledgerAtom = LedgerAtom.convert(atom);
+		} catch (LedgerAtomConversionException e) {
+			throw new IllegalStateException();
+		}
+		return new MempoolAtomAddedMessage(1, ledgerAtom);
 	}
 }

--- a/radixdlt/src/test/java/org/radix/serialization/MempoolAtomAddedMessageSerializeTest.java
+++ b/radixdlt/src/test/java/org/radix/serialization/MempoolAtomAddedMessageSerializeTest.java
@@ -19,7 +19,6 @@ package org.radix.serialization;
 
 import com.radixdlt.atommodel.Atom;
 import com.radixdlt.atommodel.message.MessageParticle;
-import com.radixdlt.constraintmachine.Particle;
 import com.radixdlt.constraintmachine.Spin;
 import com.radixdlt.identifiers.RadixAddress;
 import com.radixdlt.mempool.messages.MempoolAtomAddedMessage;
@@ -37,7 +36,7 @@ public class MempoolAtomAddedMessageSerializeTest extends SerializeMessageObject
 		atom.addParticleGroupWith(new MessageParticle(address, address, "Hello".getBytes()), Spin.UP);
 		final LedgerAtom ledgerAtom;
 		try {
-			ledgerAtom = LedgerAtom.convert(atom);
+			ledgerAtom = LedgerAtom.convertFromApiAtom(atom);
 		} catch (LedgerAtomConversionException e) {
 			throw new IllegalStateException();
 		}

--- a/radixdlt/src/test/java/org/radix/serialization/ProposalSerializeTest.java
+++ b/radixdlt/src/test/java/org/radix/serialization/ProposalSerializeTest.java
@@ -32,7 +32,7 @@ import com.radixdlt.crypto.ECKeyPair;
 import com.radixdlt.crypto.Hash;
 import com.radixdlt.identifiers.RadixAddress;
 import com.radixdlt.middleware2.LedgerAtom;
-import com.radixdlt.middleware2.LedgerAtom.CMAtomConversionException;
+import com.radixdlt.middleware2.LedgerAtom.LedgerAtomConversionException;
 
 public class ProposalSerializeTest extends SerializeObject<Proposal> {
 	public ProposalSerializeTest() {
@@ -55,7 +55,7 @@ public class ProposalSerializeTest extends SerializeObject<Proposal> {
 		final LedgerAtom reAtom;
 		try {
 			reAtom = LedgerAtom.convert(atom);
-		} catch (CMAtomConversionException e) {
+		} catch (LedgerAtomConversionException e) {
 			throw new IllegalStateException();
 		}
 		// add a particle to ensure atom is valid and has at least one shard

--- a/radixdlt/src/test/java/org/radix/serialization/ProposalSerializeTest.java
+++ b/radixdlt/src/test/java/org/radix/serialization/ProposalSerializeTest.java
@@ -31,9 +31,8 @@ import com.radixdlt.crypto.ECDSASignatures;
 import com.radixdlt.crypto.ECKeyPair;
 import com.radixdlt.crypto.Hash;
 import com.radixdlt.identifiers.RadixAddress;
-import com.radixdlt.middleware.RadixEngineUtils;
-import com.radixdlt.middleware.RadixEngineUtils.CMAtomConversionException;
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
+import com.radixdlt.middleware2.LedgerAtom.CMAtomConversionException;
 
 public class ProposalSerializeTest extends SerializeObject<Proposal> {
 	public ProposalSerializeTest() {
@@ -53,9 +52,9 @@ public class ProposalSerializeTest extends SerializeObject<Proposal> {
 		RadixAddress address = RadixAddress.from("JH1P8f3znbyrDj8F4RWpix7hRkgxqHjdW2fNnKpR3v6ufXnknor");
 		Atom atom = new Atom();
 		atom.addParticleGroupWith(new MessageParticle(address, address, "Hello".getBytes()), Spin.UP);
-		final SimpleRadixEngineAtom reAtom;
+		final LedgerAtom reAtom;
 		try {
-			reAtom = RadixEngineUtils.toCMAtom(atom);
+			reAtom = LedgerAtom.convert(atom);
 		} catch (CMAtomConversionException e) {
 			throw new IllegalStateException();
 		}

--- a/radixdlt/src/test/java/org/radix/serialization/ProposalSerializeTest.java
+++ b/radixdlt/src/test/java/org/radix/serialization/ProposalSerializeTest.java
@@ -52,14 +52,14 @@ public class ProposalSerializeTest extends SerializeObject<Proposal> {
 		RadixAddress address = RadixAddress.from("JH1P8f3znbyrDj8F4RWpix7hRkgxqHjdW2fNnKpR3v6ufXnknor");
 		Atom atom = new Atom();
 		atom.addParticleGroupWith(new MessageParticle(address, address, "Hello".getBytes()), Spin.UP);
-		final LedgerAtom reAtom;
+		final LedgerAtom ledgerAtom;
 		try {
-			reAtom = LedgerAtom.convert(atom);
+			ledgerAtom = LedgerAtom.convertFromApiAtom(atom);
 		} catch (LedgerAtomConversionException e) {
 			throw new IllegalStateException();
 		}
 		// add a particle to ensure atom is valid and has at least one shard
-		Vertex vertex = Vertex.createVertex(qc, view, reAtom);
+		Vertex vertex = Vertex.createVertex(qc, view, ledgerAtom);
 		return new Proposal(vertex, ECKeyPair.generateNew().getPublicKey(), new ECDSASignature());
 	}
 }

--- a/radixdlt/src/test/java/org/radix/serialization/ProposalSerializeTest.java
+++ b/radixdlt/src/test/java/org/radix/serialization/ProposalSerializeTest.java
@@ -17,6 +17,9 @@
 
 package org.radix.serialization;
 
+import static org.mockito.Mockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+
 import com.radixdlt.atommodel.Atom;
 import com.radixdlt.atommodel.message.MessageParticle;
 import com.radixdlt.consensus.Proposal;
@@ -31,6 +34,7 @@ import com.radixdlt.crypto.ECDSASignatures;
 import com.radixdlt.crypto.ECKeyPair;
 import com.radixdlt.crypto.Hash;
 import com.radixdlt.identifiers.RadixAddress;
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 
 public class ProposalSerializeTest extends SerializeObject<Proposal> {
 	public ProposalSerializeTest() {
@@ -48,10 +52,12 @@ public class ProposalSerializeTest extends SerializeObject<Proposal> {
 		QuorumCertificate qc = new QuorumCertificate(voteData, new ECDSASignatures());
 
 		RadixAddress address = RadixAddress.from("JH1P8f3znbyrDj8F4RWpix7hRkgxqHjdW2fNnKpR3v6ufXnknor");
+		SimpleRadixEngineAtom reAtom = mock(SimpleRadixEngineAtom.class);
 		Atom atom = new Atom();
+		when(reAtom.getAtom()).thenReturn(atom);
 		// add a particle to ensure atom is valid and has at least one shard
 		atom.addParticleGroupWith(new MessageParticle(address, address, "Hello".getBytes()), Spin.UP);
-		Vertex vertex = Vertex.createVertex(qc, view, atom);
+		Vertex vertex = Vertex.createVertex(qc, view, reAtom);
 
 
 		return new Proposal(vertex, ECKeyPair.generateNew().getPublicKey(), new ECDSASignature());

--- a/radixdlt/src/test/java/org/radix/serialization/VertexSerializeTest.java
+++ b/radixdlt/src/test/java/org/radix/serialization/VertexSerializeTest.java
@@ -17,9 +17,6 @@
 
 package org.radix.serialization;
 
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
-
 import com.radixdlt.atommodel.message.MessageParticle;
 import com.radixdlt.consensus.VoteData;
 import com.radixdlt.identifiers.RadixAddress;
@@ -31,6 +28,8 @@ import com.radixdlt.consensus.VertexMetadata;
 import com.radixdlt.constraintmachine.Spin;
 import com.radixdlt.crypto.ECDSASignatures;
 import com.radixdlt.crypto.Hash;
+import com.radixdlt.middleware.RadixEngineUtils;
+import com.radixdlt.middleware.RadixEngineUtils.CMAtomConversionException;
 import com.radixdlt.middleware.SimpleRadixEngineAtom;
 
 public class VertexSerializeTest extends SerializeObject<Vertex> {
@@ -52,8 +51,12 @@ public class VertexSerializeTest extends SerializeObject<Vertex> {
 		Atom atom = new Atom();
 		// add a particle to ensure atom is valid and has at least one shard
 		atom.addParticleGroupWith(new MessageParticle(address, address, "Hello".getBytes()), Spin.UP);
-		SimpleRadixEngineAtom reAtom = mock(SimpleRadixEngineAtom.class);
-		when(reAtom.getAtom()).thenReturn(atom);
+		final SimpleRadixEngineAtom reAtom;
+		try {
+			reAtom = RadixEngineUtils.toCMAtom(atom);
+		} catch (CMAtomConversionException e) {
+			throw new IllegalStateException();
+		}
 
 		return Vertex.createVertex(qc, view, reAtom);
 	}

--- a/radixdlt/src/test/java/org/radix/serialization/VertexSerializeTest.java
+++ b/radixdlt/src/test/java/org/radix/serialization/VertexSerializeTest.java
@@ -29,7 +29,7 @@ import com.radixdlt.constraintmachine.Spin;
 import com.radixdlt.crypto.ECDSASignatures;
 import com.radixdlt.crypto.Hash;
 import com.radixdlt.middleware2.LedgerAtom;
-import com.radixdlt.middleware2.LedgerAtom.CMAtomConversionException;
+import com.radixdlt.middleware2.LedgerAtom.LedgerAtomConversionException;
 
 public class VertexSerializeTest extends SerializeObject<Vertex> {
 	public VertexSerializeTest() {
@@ -53,7 +53,7 @@ public class VertexSerializeTest extends SerializeObject<Vertex> {
 		final LedgerAtom reAtom;
 		try {
 			reAtom = LedgerAtom.convert(atom);
-		} catch (CMAtomConversionException e) {
+		} catch (LedgerAtomConversionException e) {
 			throw new IllegalStateException();
 		}
 

--- a/radixdlt/src/test/java/org/radix/serialization/VertexSerializeTest.java
+++ b/radixdlt/src/test/java/org/radix/serialization/VertexSerializeTest.java
@@ -50,13 +50,13 @@ public class VertexSerializeTest extends SerializeObject<Vertex> {
 		Atom atom = new Atom();
 		// add a particle to ensure atom is valid and has at least one shard
 		atom.addParticleGroupWith(new MessageParticle(address, address, "Hello".getBytes()), Spin.UP);
-		final LedgerAtom reAtom;
+		final LedgerAtom ledgerAtom;
 		try {
-			reAtom = LedgerAtom.convert(atom);
+			ledgerAtom = LedgerAtom.convertFromApiAtom(atom);
 		} catch (LedgerAtomConversionException e) {
 			throw new IllegalStateException();
 		}
 
-		return Vertex.createVertex(qc, view, reAtom);
+		return Vertex.createVertex(qc, view, ledgerAtom);
 	}
 }

--- a/radixdlt/src/test/java/org/radix/serialization/VertexSerializeTest.java
+++ b/radixdlt/src/test/java/org/radix/serialization/VertexSerializeTest.java
@@ -28,9 +28,8 @@ import com.radixdlt.consensus.VertexMetadata;
 import com.radixdlt.constraintmachine.Spin;
 import com.radixdlt.crypto.ECDSASignatures;
 import com.radixdlt.crypto.Hash;
-import com.radixdlt.middleware.RadixEngineUtils;
-import com.radixdlt.middleware.RadixEngineUtils.CMAtomConversionException;
-import com.radixdlt.middleware.SimpleRadixEngineAtom;
+import com.radixdlt.middleware2.LedgerAtom;
+import com.radixdlt.middleware2.LedgerAtom.CMAtomConversionException;
 
 public class VertexSerializeTest extends SerializeObject<Vertex> {
 	public VertexSerializeTest() {
@@ -51,9 +50,9 @@ public class VertexSerializeTest extends SerializeObject<Vertex> {
 		Atom atom = new Atom();
 		// add a particle to ensure atom is valid and has at least one shard
 		atom.addParticleGroupWith(new MessageParticle(address, address, "Hello".getBytes()), Spin.UP);
-		final SimpleRadixEngineAtom reAtom;
+		final LedgerAtom reAtom;
 		try {
-			reAtom = RadixEngineUtils.toCMAtom(atom);
+			reAtom = LedgerAtom.convert(atom);
 		} catch (CMAtomConversionException e) {
 			throw new IllegalStateException();
 		}

--- a/radixdlt/src/test/java/org/radix/serialization/VertexSerializeTest.java
+++ b/radixdlt/src/test/java/org/radix/serialization/VertexSerializeTest.java
@@ -17,6 +17,9 @@
 
 package org.radix.serialization;
 
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+
 import com.radixdlt.atommodel.message.MessageParticle;
 import com.radixdlt.consensus.VoteData;
 import com.radixdlt.identifiers.RadixAddress;
@@ -28,6 +31,7 @@ import com.radixdlt.consensus.VertexMetadata;
 import com.radixdlt.constraintmachine.Spin;
 import com.radixdlt.crypto.ECDSASignatures;
 import com.radixdlt.crypto.Hash;
+import com.radixdlt.middleware.SimpleRadixEngineAtom;
 
 public class VertexSerializeTest extends SerializeObject<Vertex> {
 	public VertexSerializeTest() {
@@ -48,7 +52,9 @@ public class VertexSerializeTest extends SerializeObject<Vertex> {
 		Atom atom = new Atom();
 		// add a particle to ensure atom is valid and has at least one shard
 		atom.addParticleGroupWith(new MessageParticle(address, address, "Hello".getBytes()), Spin.UP);
+		SimpleRadixEngineAtom reAtom = mock(SimpleRadixEngineAtom.class);
+		when(reAtom.getAtom()).thenReturn(atom);
 
-		return Vertex.createVertex(qc, view, atom);
+		return Vertex.createVertex(qc, view, reAtom);
 	}
 }


### PR DESCRIPTION
* Implement RadixEngine's RadixEngineAtom with consensus specific LedgerAtom
* Move most middleware classes from RadixEngine to core
* Use Atom only for api side (deprecate in the future)