### PR TITLE
Add validator FSM support 

### DIFF
--- a/radixdlt/build.gradle
+++ b/radixdlt/build.gradle
@@ -83,7 +83,7 @@ jacocoTestReport {
 }
 
 dependencies {
-    compile 'com.radixdlt:radix-engine-library:feature~refactor-api-SNAPSHOT'
+    compile 'com.radixdlt:radix-engine-library:rc~1.0-beta.10-SNAPSHOT'
 
     compile 'io.reactivex.rxjava3:rxjava:3.0.0'
     compile 'com.sleepycat:je:18.3.12'

--- a/radixdlt/src/main/java/com/radixdlt/consensus/validators/Validator.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/validators/Validator.java
@@ -28,42 +28,6 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 public final class Validator {
-/*	FIXME: Functionality not required until drop 2
-	public enum BondStatus {
-		UNBONDED,
-		BONDED,
-		UNBONDING;
-	}
-
-	// Current bonding status
-	private BondStatus bondStatus;
-
-	@JsonProperty("reward_address")
-	@DsonOutput(Output.ALL)
-	// Address for rewards
-	private final RadixAddress rewardAddress;
-
-	@JsonProperty("bond_view")
-	@DsonOutput(Output.ALL)
-	// View when bonding occurred, possibly null
-	private final View bondView;
-
-	@JsonProperty("unbond_view")
-	@DsonOutput(Output.ALL)
-	// View when unbonding started, possibly null
-	private final View unbondView;
-
-	@JsonProperty("unbond_completion")
-	@DsonOutput(Output.ALL)
-	// Unix millisecond time when unbonding finishes, only valid if unboundView != null
-	private final long unbondCompletion;
-
-	@JsonProperty("jailed")
-	@DsonOutput(Output.ALL)
-	// True if jailed, false otherwise
-	private final boolean jailed;
-*/
-
 	// Power associated with each validator, could e.g. be based on staked tokens
 	private final UInt256 power;
 

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/MiddlewareModule.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/MiddlewareModule.java
@@ -26,6 +26,7 @@ import com.radixdlt.DefaultSerialization;
 import com.radixdlt.atommodel.message.MessageParticleConstraintScrypt;
 import com.radixdlt.atommodel.tokens.TokensConstraintScrypt;
 import com.radixdlt.atommodel.unique.UniqueParticleConstraintScrypt;
+import com.radixdlt.atommodel.validators.ValidatorConstraintScrypt;
 import com.radixdlt.atomos.CMAtomOS;
 import com.radixdlt.atomos.Result;
 import com.radixdlt.constraintmachine.ConstraintMachine;
@@ -60,6 +61,7 @@ public class MiddlewareModule extends AbstractModule {
 		os.load(new TokensConstraintScrypt());
 		os.load(new UniqueParticleConstraintScrypt());
 		os.load(new MessageParticleConstraintScrypt());
+		os.load(new ValidatorConstraintScrypt());
 		return os;
 	}
 

--- a/radixdlt/src/main/resources/schemas/atom.schema.json
+++ b/radixdlt/src/main/resources/schemas/atom.schema.json
@@ -133,7 +133,9 @@
         { "$ref": "#/definitions/messageParticle" },
         { "$ref": "#/definitions/unallocatedTokensParticle" },
         { "$ref": "#/definitions/transferrableTokensParticle" },
-        { "$ref": "#/definitions/uniqueParticle" }
+        { "$ref": "#/definitions/uniqueParticle" },
+        { "$ref": "#/definitions/registeredValidatorParticle" },
+        { "$ref": "#/definitions/unregisteredValidatorParticle" }
       ],
       "description": "A particle which is a component which represents a substate of the ledger."
     },
@@ -334,6 +336,48 @@
         "nonce": { "type": "number" }
       },
       "description": "A particle which makes the containing Atom unique."
+    },
+    "registeredValidatorParticle": {
+      "type": "object",
+      "properties": {
+        "destinations": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/uid" },
+          "minItems": 1
+        },
+        "serializer": {
+          "type": "string",
+          "enum": [ "radix.particles.registered_validator" ]
+        },
+        "address": { "$ref": "#/definitions/address" },
+        "nonce": { "type": "number" }
+      },
+      "description": "A particle which marks a validator address as registered."
+    },
+    "unregisteredValidatorParticle": {
+      "type": "object",
+      "properties": {
+        "destinations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/uid"
+          },
+          "minItems": 1
+        },
+        "serializer": {
+          "type": "string",
+          "enum": [
+            "radix.particles.unregistered_validator"
+          ]
+        },
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "nonce": {
+          "type": "number"
+        }
+      },
+      "description": "A particle which marks a validator address as unregistered."
     }
   }
 }

--- a/radixdlt/src/main/resources/schemas/atom.schema.json
+++ b/radixdlt/src/main/resources/schemas/atom.schema.json
@@ -352,6 +352,7 @@
         "address": { "$ref": "#/definitions/address" },
         "nonce": { "type": "number" }
       },
+      "required": [ "serializer", "address", "nonce" ],
       "description": "A particle which marks a validator address as registered."
     },
     "unregisteredValidatorParticle": {
@@ -377,6 +378,7 @@
           "type": "number"
         }
       },
+      "required": [ "serializer", "address", "nonce" ],
       "description": "A particle which marks a validator address as unregistered."
     }
   }


### PR DESCRIPTION
Adds support for the recently introduced validator registration FSM from the engine side. Specifically, this loads the required constraint scrypt and expands the atoms schema to accommodate the new particles. 