### PR TITLE
Fix for bug RPNV1-260

### DIFF
--- a/radixdlt/src/test/java/com/radixdlt/network/transport/udp/UDPTransportOutboundConnectionTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/network/transport/udp/UDPTransportOutboundConnectionTest.java
@@ -81,6 +81,7 @@ public class UDPTransportOutboundConnectionTest {
 
 	@Before
 	public void setUp() throws UnknownHostException {
+	    Thread.interrupted();
 		channel = mock(DatagramChannel.class);
 		channelFuture = spy(new DefaultChannelPromise(channel, new DefaultEventExecutor()));
 

--- a/radixdlt/src/test/java/com/radixdlt/network/transport/udp/UDPTransportOutboundConnectionTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/network/transport/udp/UDPTransportOutboundConnectionTest.java
@@ -81,7 +81,7 @@ public class UDPTransportOutboundConnectionTest {
 
 	@Before
 	public void setUp() throws UnknownHostException {
-	    Thread.interrupted();
+		Thread.interrupted();
 		channel = mock(DatagramChannel.class);
 		channelFuture = spy(new DefaultChannelPromise(channel, new DefaultEventExecutor()));
 


### PR DESCRIPTION
For details see:https://radixdlt.atlassian.net/browse/RPNV1-260
The solution simply clears the interrupted flag on the test setup method.