### PR TITLE
Bugfix for RPNV1-148

### DIFF
--- a/radixdlt/src/main/java/com/radixdlt/consensus/BFTEventReducer.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/BFTEventReducer.java
@@ -40,6 +40,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.FormattedMessage;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -112,7 +113,7 @@ public final class BFTEventReducer implements BFTEventProcessor {
 			signature
 		);
 		ECPublicKey nextLeader = this.proposerElection.getProposer(nextView);
-		log.trace("{}: Sending NEW_VIEW to {}: {}", this.getShortName(), this.getShortName(nextLeader.euid()), newView);
+		log.trace("{}: Sending NEW_VIEW to {}: {}", this::getShortName, () -> this.getShortName(nextLeader.euid()), () ->  newView);
 		this.sender.sendNewView(newView, nextLeader);
 		this.counters.set(CounterType.CONSENSUS_VIEW, nextView.number());
 	}
@@ -122,7 +123,7 @@ public final class BFTEventReducer implements BFTEventProcessor {
 		this.safetyRules.process(qc)
 			.ifPresent(commitMetaData -> {
 				vertexStore.commitVertex(commitMetaData).ifPresent(vertex -> {
-					log.trace("{}: Committed vertex: {}", this.getShortName(), vertex);
+					log.trace("{}: Committed vertex: {}", this::getShortName, () -> vertex);
 					final ClientAtom committedAtom = vertex.getAtom();
 					if (committedAtom != null) {
 						mempool.removeCommittedAtom(committedAtom.getAID());
@@ -144,7 +145,7 @@ public final class BFTEventReducer implements BFTEventProcessor {
 		if (qc != null) {
 			if (vertexStore.syncToQC(qc, vertexStore.getHighestCommittedQC(), null)) {
 				processQC(qc);
-				log.trace("{}: LOCAL_SYNC: processed QC: {}", this.getShortName(), qc);
+				log.trace("{}: LOCAL_SYNC: processed QC: {}", this::getShortName, () ->  qc);
 			} else {
 				unsyncedQCs.put(qc.getProposed().getId(), qc);
 			}
@@ -153,14 +154,14 @@ public final class BFTEventReducer implements BFTEventProcessor {
 
 	@Override
 	public void processVote(Vote vote) {
-		log.trace("{}: VOTE: Processing {}", this.getShortName(), vote);
+		log.trace("{}: VOTE: Processing {}", this::getShortName, () -> vote);
 		// accumulate votes into QCs in store
 		this.pendingVotes.insertVote(vote, this.validatorSet).ifPresent(qc -> {
-			log.trace("{}: VOTE: Formed QC: {}", this.getShortName(), qc);
+			log.trace("{}: VOTE: Formed QC: {}", this::getShortName, () -> qc);
 			if (vertexStore.syncToQC(qc, vertexStore.getHighestCommittedQC(), vote.getAuthor())) {
 				processQC(qc);
 			} else {
-				log.trace("{}: VOTE: QC Not synced: {}", this.getShortName(), qc);
+				log.trace("{}: VOTE: QC Not synced: {}", this::getShortName, () -> qc);
 				unsyncedQCs.put(qc.getProposed().getId(), qc);
 			}
 		});
@@ -168,20 +169,20 @@ public final class BFTEventReducer implements BFTEventProcessor {
 
 	@Override
 	public void processNewView(NewView newView) {
-		log.trace("{}: NEW_VIEW: Processing {}", this.getShortName(), newView);
+		log.trace("{}: NEW_VIEW: Processing {}", this::getShortName, () -> newView);
 		processQC(newView.getQC());
 		this.pacemaker.processNewView(newView, validatorSet).ifPresent(view -> {
 			// Hotstuff's Event-Driven OnBeat
 			final Vertex proposedVertex = proposalGenerator.generateProposal(view);
 			final Proposal proposal = safetyRules.signProposal(proposedVertex, this.vertexStore.getHighestCommittedQC());
-			log.trace("{}: Broadcasting PROPOSAL: {}", getShortName(), proposal);
+			log.trace("{}: Broadcasting PROPOSAL: {}", this::getShortName, () -> proposal);
 			this.sender.broadcastProposal(proposal);
 		});
 	}
 
 	@Override
 	public void processProposal(Proposal proposal) {
-		log.trace("{}: PROPOSAL: Processing {}", this.getShortName(), proposal);
+		log.trace("{}: PROPOSAL: Processing {}", this::getShortName, () -> proposal);
 		final Vertex proposedVertex = proposal.getVertex();
 		final View proposedVertexView = proposedVertex.getView();
 
@@ -189,7 +190,7 @@ public final class BFTEventReducer implements BFTEventProcessor {
 
 		final View updatedView = this.pacemaker.getCurrentView();
 		if (proposedVertexView.compareTo(updatedView) != 0) {
-			log.trace("{}: PROPOSAL: Ignoring view {} Current is: {}", this.getShortName(), proposedVertexView, updatedView);
+			log.trace("{}: PROPOSAL: Ignoring view {} Current is: {}", this::getShortName, () -> proposedVertexView, () -> updatedView);
 			return;
 		}
 
@@ -201,9 +202,7 @@ public final class BFTEventReducer implements BFTEventProcessor {
 			vertexStore.insertVertex(proposedVertex);
 		} catch (VertexInsertionException e) {
 			counters.increment(CounterType.CONSENSUS_REJECTED);
-
-			log.trace(String.format("%s: PROPOSAL: Rejected", this.getShortName()), e);
-
+			log.trace("{} PROPOSAL: Rejected. Reason: {}", this::getShortName, e::getMessage);
 			// TODO: Better logic for removal on exception
 			final ClientAtom atom = proposedVertex.getAtom();
 			if (atom != null) {
@@ -215,17 +214,16 @@ public final class BFTEventReducer implements BFTEventProcessor {
 		final ECPublicKey currentLeader = this.proposerElection.getProposer(updatedView);
 		try {
 			final Vote vote = safetyRules.voteFor(proposedVertex);
-			log.trace("{}: PROPOSAL: Sending VOTE to {}: {}", this.getShortName(), this.getShortName(currentLeader.euid()), vote);
+			log.trace("{}: PROPOSAL: Sending VOTE to {}: {}", this::getShortName, () -> this.getShortName(currentLeader.euid()), () -> vote);
 			sender.sendVote(vote, currentLeader);
 		} catch (SafetyViolationException e) {
-			log.error(String.format("%s: PROPOSAL: Rejected %s", this.getShortName(), proposedVertex), e);
+			log.error(() -> new FormattedMessage("{}: PROPOSAL: Rejected {}", this.getShortName(), proposedVertex), e);
 		}
 
 		// If not currently leader or next leader, Proceed to next view
 		if (!Objects.equals(currentLeader, selfKey.getPublicKey())) {
 			final ECPublicKey nextLeader = this.proposerElection.getProposer(updatedView.next());
 			if (!Objects.equals(nextLeader, selfKey.getPublicKey())) {
-
 				// TODO: should not call processQC
 				this.pacemaker.processQC(updatedView).ifPresent(this::proceedToView);
 			}
@@ -235,13 +233,11 @@ public final class BFTEventReducer implements BFTEventProcessor {
 	@Override
 	public void processLocalTimeout(View view) {
 		log.trace("{}: LOCAL_TIMEOUT: Processing {}", this::getShortName, () -> view);
-
 		// proceed to next view if pacemaker feels like it
 		Optional<View> nextView = this.pacemaker.processLocalTimeout(view);
 		if (nextView.isPresent()) {
 			this.proceedToView(nextView.get());
 			log.trace("{}: LOCAL_TIMEOUT: Processed {}", this::getShortName, () -> view);
-
 			counters.set(CounterType.CONSENSUS_TIMEOUT_VIEW, view.number());
 			counters.increment(CounterType.CONSENSUS_TIMEOUT);
 		} else {

--- a/radixdlt/src/main/java/com/radixdlt/consensus/BFTEventReducer.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/BFTEventReducer.java
@@ -234,18 +234,18 @@ public final class BFTEventReducer implements BFTEventProcessor {
 
 	@Override
 	public void processLocalTimeout(View view) {
-		log.trace("{}: LOCAL_TIMEOUT: Processing {}", this.getShortName(), view);
+		log.trace("{}: LOCAL_TIMEOUT: Processing {}", this::getShortName, () -> view);
 
 		// proceed to next view if pacemaker feels like it
 		Optional<View> nextView = this.pacemaker.processLocalTimeout(view);
 		if (nextView.isPresent()) {
 			this.proceedToView(nextView.get());
-			log.trace("{}: LOCAL_TIMEOUT: Processed {}", this.getShortName(), view);
+			log.trace("{}: LOCAL_TIMEOUT: Processed {}", this::getShortName, () -> view);
 
 			counters.set(CounterType.CONSENSUS_TIMEOUT_VIEW, view.number());
 			counters.increment(CounterType.CONSENSUS_TIMEOUT);
 		} else {
-			log.trace("{}: LOCAL_TIMEOUT: Ignoring {}", this.getShortName(), view);
+			log.trace("{}: LOCAL_TIMEOUT: Ignoring {}", this::getShortName, () -> view);
 		}
 	}
 

--- a/radixdlt/src/main/java/com/radixdlt/consensus/BFTEventReducer.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/BFTEventReducer.java
@@ -17,15 +17,6 @@
 
 package com.radixdlt.consensus;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.FormattedMessage;
-
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.radixdlt.consensus.liveness.Pacemaker;
@@ -44,6 +35,13 @@ import com.radixdlt.identifiers.EUID;
 import com.radixdlt.mempool.Mempool;
 import com.radixdlt.middleware2.ClientAtom;
 import com.radixdlt.utils.Longs;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.FormattedMessage;
 
 /**
  * Processes and reduces BFT events to the BFT state based on core
@@ -69,18 +67,18 @@ public final class BFTEventReducer implements BFTEventProcessor {
 
 	@Inject
 	public BFTEventReducer(
-		ProposalGenerator proposalGenerator,
-		Mempool mempool,
-		BFTEventSender sender,
-		SafetyRules safetyRules,
-		Pacemaker pacemaker,
-		VertexStore vertexStore,
-		PendingVotes pendingVotes,
-		ProposerElection proposerElection,
-		@Named("self") ECKeyPair selfKey,
-		ValidatorSet validatorSet,
-		SystemCounters counters
-	) {
+			ProposalGenerator proposalGenerator,
+			Mempool mempool,
+			BFTEventSender sender,
+			SafetyRules safetyRules,
+			Pacemaker pacemaker,
+			VertexStore vertexStore,
+			PendingVotes pendingVotes,
+			ProposerElection proposerElection,
+			@Named("self") ECKeyPair selfKey,
+			ValidatorSet validatorSet,
+			SystemCounters counters
+			) {
 		this.proposalGenerator = Objects.requireNonNull(proposalGenerator);
 		this.mempool = Objects.requireNonNull(mempool);
 		this.sender = Objects.requireNonNull(sender);
@@ -107,12 +105,12 @@ public final class BFTEventReducer implements BFTEventProcessor {
 		// TODO make signing more robust by including author in signed hash
 		ECDSASignature signature = this.selfKey.sign(Hash.hash256(Longs.toByteArray(nextView.number())));
 		NewView newView = new NewView(
-			selfKey.getPublicKey(),
-			nextView,
-			this.vertexStore.getHighestQC(),
-			this.vertexStore.getHighestCommittedQC(),
-			signature
-		);
+				selfKey.getPublicKey(),
+				nextView,
+				this.vertexStore.getHighestQC(),
+				this.vertexStore.getHighestCommittedQC(),
+				signature
+				);
 		ECPublicKey nextLeader = this.proposerElection.getProposer(nextView);
 		log.trace("{}: Sending NEW_VIEW to {}: {}", this::getShortName, () -> this.getShortName(nextLeader.euid()), () ->  newView);
 		this.sender.sendNewView(newView, nextLeader);
@@ -122,20 +120,20 @@ public final class BFTEventReducer implements BFTEventProcessor {
 	private void processQC(QuorumCertificate qc) {
 		// commit any newly committable vertices
 		this.safetyRules.process(qc)
-			.ifPresent(commitMetaData -> {
-				vertexStore.commitVertex(commitMetaData).ifPresent(vertex -> {
-					log.trace("{}: Committed vertex: {}", this::getShortName, () -> vertex);
-					final ClientAtom committedAtom = vertex.getAtom();
-					if (committedAtom != null) {
-						mempool.removeCommittedAtom(committedAtom.getAID());
-					}
-				});
-
+		.ifPresent(commitMetaData -> {
+			vertexStore.commitVertex(commitMetaData).ifPresent(vertex -> {
+				log.trace("{}: Committed vertex: {}", this::getShortName, () -> vertex);
+				final ClientAtom committedAtom = vertex.getAtom();
+				if (committedAtom != null) {
+					mempool.removeCommittedAtom(committedAtom.getAID());
+				}
 			});
+
+		});
 
 		// proceed to next view if pacemaker feels like it
 		this.pacemaker.processQC(qc.getView())
-			.ifPresent(this::proceedToView);
+		.ifPresent(this::proceedToView);
 	}
 
 	@Override
@@ -255,6 +253,6 @@ public final class BFTEventReducer implements BFTEventProcessor {
 	@Override
 	public void start() {
 		this.pacemaker.processQC(this.vertexStore.getHighestQC().getView())
-			.ifPresent(this::proceedToView);
+		.ifPresent(this::proceedToView);
 	}
 }

--- a/radixdlt/src/main/java/com/radixdlt/consensus/liveness/ScheduledTimeoutSender.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/liveness/ScheduledTimeoutSender.java
@@ -17,7 +17,6 @@
 
 package com.radixdlt.consensus.liveness;
 
-
 import com.radixdlt.consensus.View;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Observable;

--- a/radixdlt/src/main/java/com/radixdlt/consensus/liveness/ScheduledTimeoutSender.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/liveness/ScheduledTimeoutSender.java
@@ -38,7 +38,7 @@ public final class ScheduledTimeoutSender implements FixedTimeoutPacemaker.Timeo
 	private final ScheduledExecutorService executorService;
 	private final Subject<View> timeouts;
 	private final Observable<View> timeoutsObservable;
-	private volatile long nextLogging = 0;
+	private long nextLogging = 0;
 
 	public ScheduledTimeoutSender(ScheduledExecutorService executorService) {
 		this.executorService = Objects.requireNonNull(executorService);
@@ -51,13 +51,13 @@ public final class ScheduledTimeoutSender implements FixedTimeoutPacemaker.Timeo
 
 	@Override
 	public void scheduleTimeout(final View view, long timeoutMilliseconds) {
-	    long crtTime = System.currentTimeMillis();
-	    if (crtTime >= nextLogging) {
-	        log.info("Starting View: {}", view);
-	        nextLogging = crtTime + LOGGING_INTERVAL;
-	    } else {
-	        log.trace("Starting View: {}", view);
-	    }
+		long crtTime = System.currentTimeMillis();
+		if (crtTime >= nextLogging) {
+			log.info("Starting View: {}", view);
+			nextLogging = crtTime + LOGGING_INTERVAL;
+		} else {
+			log.trace("Starting View: {}", view);
+		}
 		executorService.schedule(() -> timeouts.onNext(view), timeoutMilliseconds, TimeUnit.MILLISECONDS);
 	}
 

--- a/radixdlt/src/main/java/com/radixdlt/consensus/liveness/ScheduledTimeoutSender.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/liveness/ScheduledTimeoutSender.java
@@ -34,13 +34,12 @@ import org.apache.logging.log4j.Logger;
  */
 public final class ScheduledTimeoutSender implements FixedTimeoutPacemaker.TimeoutSender, PacemakerRx {
 	private static final Logger log = LogManager.getLogger();
-    private static final long LOGGING_INTERVAL = TimeUnit.SECONDS.toMillis(1);	
+	private static final long LOGGING_INTERVAL = TimeUnit.SECONDS.toMillis(1);
 	private final ScheduledExecutorService executorService;
 	private final Subject<View> timeouts;
 	private final Observable<View> timeoutsObservable;
-
 	private volatile long nextLogging = 0;
-	
+
 	public ScheduledTimeoutSender(ScheduledExecutorService executorService) {
 		this.executorService = Objects.requireNonNull(executorService);
 		// BehaviorSubject so that nextLocalTimeout will complete if timeout already occurred
@@ -53,11 +52,11 @@ public final class ScheduledTimeoutSender implements FixedTimeoutPacemaker.Timeo
 	@Override
 	public void scheduleTimeout(final View view, long timeoutMilliseconds) {
 	    long crtTime = System.currentTimeMillis();
-	    if(crtTime >= nextLogging) {
+	    if (crtTime >= nextLogging) {
 	        log.info("Starting View: {}", view);
 	        nextLogging = crtTime + LOGGING_INTERVAL;
-	    }else {	        
-	        log.trace("Starting View: {}", view);    	        	       
+	    } else {
+	        log.trace("Starting View: {}", view);
 	    }
 		executorService.schedule(() -> timeouts.onNext(view), timeoutMilliseconds, TimeUnit.MILLISECONDS);
 	}

--- a/radixdlt/src/main/java/com/radixdlt/consensus/liveness/ScheduledTimeoutSender.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/liveness/ScheduledTimeoutSender.java
@@ -39,7 +39,7 @@ public final class ScheduledTimeoutSender implements FixedTimeoutPacemaker.Timeo
 	private final Subject<View> timeouts;
 	private final Observable<View> timeoutsObservable;
 
-	private long nextLogging = 0;
+	private volatile long nextLogging = 0;
 	
 	public ScheduledTimeoutSender(ScheduledExecutorService executorService) {
 		this.executorService = Objects.requireNonNull(executorService);
@@ -56,7 +56,9 @@ public final class ScheduledTimeoutSender implements FixedTimeoutPacemaker.Timeo
 	    if(crtTime >= nextLogging) {
 	        log.info("Starting View: {}", view);
 	        nextLogging = crtTime + LOGGING_INTERVAL;
-	    }	
+	    }else {	        
+	        log.trace("Starting View: {}", view);    	        	       
+	    }
 		executorService.schedule(() -> timeouts.onNext(view), timeoutMilliseconds, TimeUnit.MILLISECONDS);
 	}
 


### PR DESCRIPTION
Switched to trace level logging with lambda parameters in BFTEventReducer.
Logging starting view message in ScheduledTimeoutSender only after at least one second had passed since the previous log statement.

For ticket details see: https://radixdlt.atlassian.net/browse/RPNV1-148