### PR TITLE
Fix for bug RPNV1-251

### DIFF
--- a/radixdlt/src/main/resources/schemas/atom.schema.json
+++ b/radixdlt/src/main/resources/schemas/atom.schema.json
@@ -193,7 +193,7 @@
         }
       },
       "additionalProperties": false,
-      "required": [ "serializer", "rri", "name", "description", "permissions" ],
+      "required": [ "serializer", "rri", "name", "permissions" ],
       "description": "A particle which represents a token class state."
     },
     "fixedSupplyTokenDefinitionParticle": {
@@ -220,7 +220,7 @@
         }
       },
       "additionalProperties": false,
-      "required": [ "serializer", "rri", "name", "description", "supply" ],
+      "required": [ "serializer", "rri", "name", "supply" ],
       "description": "A particle which represents a token class state."
     },
     "messageParticle": {


### PR DESCRIPTION
I updated the aton.schema.json so the field  **description**" is not required anymore for **mutableSupplyTokenDefinitionParticle** and **fixedSupplyTokenDefinitionParticle** requests.

For ticket details see:https://radixdlt.atlassian.net/browse/RPNV1-251