### PR TITLE
Basic delegated staking

### DIFF
--- a/radixdlt/src/main/resources/schemas/atom.schema.json
+++ b/radixdlt/src/main/resources/schemas/atom.schema.json
@@ -133,6 +133,7 @@
         { "$ref": "#/definitions/messageParticle" },
         { "$ref": "#/definitions/unallocatedTokensParticle" },
         { "$ref": "#/definitions/transferrableTokensParticle" },
+        { "$ref": "#/definitions/stakedTokensParticle" },
         { "$ref": "#/definitions/uniqueParticle" },
         { "$ref": "#/definitions/registeredValidatorParticle" },
         { "$ref": "#/definitions/unregisteredValidatorParticle" }
@@ -317,6 +318,48 @@
       },
       "additionalProperties": false,
       "required": [ "serializer", "amount", "nonce", "planck", "tokenDefinitionReference" ],
+      "description": "A particle which represents an amount of a token owned by an account."
+    },
+    "stakedTokensParticle": {
+      "type": "object",
+      "properties": {
+        "destinations": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/uid" },
+          "minItems": 1
+        },
+        "serializer": {
+          "type": "string",
+          "enum": [ "radix.particles.staked_tokens" ]
+        },
+        "version": {
+          "type": "number"
+        },
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "delegateAddress": {
+          "$ref": "#/definitions/address"
+        },
+        "tokenDefinitionReference": {
+          "$ref": "#/definitions/radixResourceIdentifier"
+        },
+        "permissions": {
+          "type": "object",
+          "properties": {
+            "burn": { "$ref": "#/definitions/tokenActionPermission" },
+            "mint": { "$ref": "#/definitions/tokenActionPermission" }
+          },
+          "required": [ "burn", "mint" ],
+          "additionalProperties": false
+        },
+        "granularity": { "$ref": "#/definitions/u20" },
+        "nonce": { "type": "number" },
+        "planck": { "type": "number" },
+        "amount": { "$ref": "#/definitions/u20" }
+      },
+      "additionalProperties": false,
+      "required": [ "serializer", "address", "delegateAddress", "amount", "nonce", "planck", "tokenDefinitionReference" ],
       "description": "A particle which represents an amount of a token owned by an account."
     },
     "uniqueParticle": {

--- a/radixdlt/src/main/resources/schemas/atom.schema.json
+++ b/radixdlt/src/main/resources/schemas/atom.schema.json
@@ -360,7 +360,7 @@
       },
       "additionalProperties": false,
       "required": [ "serializer", "address", "delegateAddress", "amount", "nonce", "planck", "tokenDefinitionReference" ],
-      "description": "A particle which represents an amount of a token owned by an account."
+      "description": "A particle which represents an amount of tokens owned by an account staked to a delegate account."
     },
     "uniqueParticle": {
       "type": "object",


### PR DESCRIPTION
Updates our atom schema to support basic delegated staking via a new `StakedTokensParticle` state for instantiated tokens as described [in our design](https://radixdlt.atlassian.net/wiki/spaces/RPNV1/pages/851640333/Proof+Of+Stake+v1).