### PR TITLE
Reduce open cursors next committed

### DIFF
--- a/radixdlt/src/integration/java/com/radixdlt/store/berkeley/BerkeleyRadixLedgerEntryStoreTests.java
+++ b/radixdlt/src/integration/java/com/radixdlt/store/berkeley/BerkeleyRadixLedgerEntryStoreTests.java
@@ -82,6 +82,7 @@ public class BerkeleyRadixLedgerEntryStoreTests extends RadixTestWithStores {
             softly.assertThat(ledgerStore.getNextCommitted(ledgerEntries.get(0).getStateVersion() - 1, 1))
                 .contains(ledgerEntries.get(0).getAID());
 
+            // committed ledger entry can be queried by version
             softly.assertThat(ledgerStore.getNextCommittedLedgerEntries(ledgerEntries.get(0).getStateVersion() - 1, 1))
                     .contains(ledgerEntries.get(0));
 
@@ -115,18 +116,10 @@ public class BerkeleyRadixLedgerEntryStoreTests extends RadixTestWithStores {
                         .contains(ledgerEntries.get(i));
             }
 
+            // verify that five atoms in total have been committed and can be returned
             softly.assertThat(ledgerStore.getNextCommittedLedgerEntries(ledgerEntries.get(0).getStateVersion()-1, 10)).size().isEqualTo(5);
 
-//            // use limit 2 and see if both returned
-//            for (int i=0; i < ledgerEntries.size()-2; ++i) {
-//                // committed atom can be queried by version
-//                softly.assertThat(ledgerStore.getNextCommitted(ledgerEntries.get(i).getStateVersion() - 1, 2))
-//                        .contains(ledgerEntries.get(i).getAID()).contains(ledgerEntries.get(i+i).getAID());
-//
-//                softly.assertThat(ledgerStore.getNextCommittedLedgerEntries(ledgerEntries.get(i).getStateVersion() - 1, 2))
-//                        .contains(ledgerEntries.get(i)).contains(ledgerEntries.get(i+1));
-//            }
-
+            // TODO more advanced testing using different limits
         });
     }
 

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/store/CommittedAtomsStore.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/store/CommittedAtomsStore.java
@@ -130,20 +130,7 @@ public class CommittedAtomsStore implements EngineStore<CommittedAtom> {
 	 * @param limit limit to number of atoms to return
 	 * @return list of committed atoms
 	 */
-//	public List<CommittedAtom> getCommittedAtoms(long stateVersion, int limit) {
-//		// TODO: currently this is very inefficient, optimize so that we can make one pass through the store
-//		return store.getNextCommitted(stateVersion, limit)
-//				.stream()
-//				.map(store::get)
-//				.filter(Optional::isPresent)
-//				.map(Optional::get)
-//				.map(LedgerEntry::getContent)
-//				.map(atomToBinaryConverter::toAtom)
-//				.collect(ImmutableList.toImmutableList());
-//	}
-
 	public List<CommittedAtom> getCommittedAtoms(long stateVersion, int limit) {
-		// TODO: currently this is very inefficient, optimize so that we can make one pass through the store
 		ImmutableList<LedgerEntry> entries = store.getNextCommittedLedgerEntries(stateVersion, limit);
 		return entries
 				.stream()

--- a/radixdlt/src/main/java/com/radixdlt/middleware2/store/CommittedAtomsStore.java
+++ b/radixdlt/src/main/java/com/radixdlt/middleware2/store/CommittedAtomsStore.java
@@ -130,16 +130,26 @@ public class CommittedAtomsStore implements EngineStore<CommittedAtom> {
 	 * @param limit limit to number of atoms to return
 	 * @return list of committed atoms
 	 */
+//	public List<CommittedAtom> getCommittedAtoms(long stateVersion, int limit) {
+//		// TODO: currently this is very inefficient, optimize so that we can make one pass through the store
+//		return store.getNextCommitted(stateVersion, limit)
+//				.stream()
+//				.map(store::get)
+//				.filter(Optional::isPresent)
+//				.map(Optional::get)
+//				.map(LedgerEntry::getContent)
+//				.map(atomToBinaryConverter::toAtom)
+//				.collect(ImmutableList.toImmutableList());
+//	}
+
 	public List<CommittedAtom> getCommittedAtoms(long stateVersion, int limit) {
 		// TODO: currently this is very inefficient, optimize so that we can make one pass through the store
-		return store.getNextCommitted(stateVersion, limit)
-			.stream()
-			.map(store::get)
-			.filter(Optional::isPresent)
-			.map(Optional::get)
-			.map(LedgerEntry::getContent)
-			.map(atomToBinaryConverter::toAtom)
-			.collect(ImmutableList.toImmutableList());
+		ImmutableList<LedgerEntry> entries = store.getNextCommittedLedgerEntries(stateVersion, limit);
+		return entries
+				.stream()
+				.map(LedgerEntry::getContent)
+				.map(atomToBinaryConverter::toAtom)
+				.collect(ImmutableList.toImmutableList());
 	}
 
 	/**

--- a/radixdlt/src/main/java/com/radixdlt/store/LedgerEntryStoreView.java
+++ b/radixdlt/src/main/java/com/radixdlt/store/LedgerEntryStoreView.java
@@ -90,4 +90,13 @@ public interface LedgerEntryStoreView {
 	 * @return The relevant aids
 	 */
 	ImmutableList<AID> getNextCommitted(long stateVersion, int limit);
+
+	/**
+	 * Retrieve a chunk of {@link LedgerEntry} with state version greater than the given one
+	 * in sequential order.
+	 * @param stateVersion the state version to use as a search parameter
+	 * @param limit the maximum count of ledger entries to return
+	 * @return ledger entries satisfying the constraints
+	 */
+	ImmutableList<LedgerEntry> getNextCommittedLedgerEntries(long stateVersion, int limit);
 }

--- a/radixdlt/src/main/java/com/radixdlt/store/berkeley/BerkeleyLedgerEntryStore.java
+++ b/radixdlt/src/main/java/com/radixdlt/store/berkeley/BerkeleyLedgerEntryStore.java
@@ -487,19 +487,13 @@ public class BerkeleyLedgerEntryStore implements LedgerEntryStore {
 				}
 
 				AID atomId = getAidFromPKey(atomSearchKey);
-				// TODO replace with uqCursor usage
-//				 Optional<LedgerEntry> ledgerEntry = this.get(atomId);
-//				 if (ledgerEntry.isPresent()) {
-//				 	ledgerEntries.add(ledgerEntry.get());
-//				 	++size;
-//				 }
-
 				LedgerEntry ledgerEntry = null;
 				try {
 					DatabaseEntry key = new DatabaseEntry(StoreIndex.from(ENTRY_INDEX_PREFIX, atomId.getBytes()));
 					DatabaseEntry value = new DatabaseEntry();
 					OperationStatus uqCursorStatus = uqCursor.getSearchKey(key, value, LockMode.DEFAULT);
 
+					// TODO when uqCursor fails to fetch value, which means some form of DB corruption has occurred, how should we handle it?
 					if (uqCursorStatus == OperationStatus.SUCCESS) {
 						ledgerEntry = serialization.fromDson(value.getData(), LedgerEntry.class);
 						ledgerEntries.add(ledgerEntry);

--- a/radixdlt/src/test/java/com/radixdlt/middleware2/store/CommittedAtomsStoreTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/middleware2/store/CommittedAtomsStoreTest.java
@@ -20,9 +20,7 @@ package com.radixdlt.middleware2.store;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 import com.google.common.collect.ImmutableList;
@@ -38,6 +36,7 @@ import com.radixdlt.middleware2.store.CommittedAtomsStore.AtomIndexer;
 import com.radixdlt.store.LedgerEntry;
 import com.radixdlt.store.LedgerEntryStore;
 import com.radixdlt.store.SearchCursor;
+import com.radixdlt.store.berkeley.BerkeleyLedgerEntryStore;
 import io.reactivex.rxjava3.observers.TestObserver;
 import java.util.Collections;
 import java.util.Optional;
@@ -56,7 +55,7 @@ public class CommittedAtomsStoreTest {
 
 	@Before
 	public void setUp() {
-		this.store = mock(LedgerEntryStore.class);
+		this.store = mock(LedgerEntryStore.class, withSettings().verboseLogging());
 		this.atomToBinaryConverter = mock(AtomToBinaryConverter.class);
 		this.atomIndexer = mock(AtomIndexer.class);
 		this.counters = mock(SystemCounters.class);


### PR DESCRIPTION
The current implementation in CommittedAtomsStore.getCommittedAtoms uses an approach that first pulls all committed atom ids and then fetches them by repeatedly fetching individual LedgerEntry. This results in repeatedly opening a new cursor. It is more efficient to address this by scrolling a single cursor. Architecturally, this could be done in one of two ways:

adding a new method to the ledger store that takes a Collection of AtomIDs and returns a List of LedgerEntry
adding a new method to the ledger store that returns an ImmutableList of committed LedgerEntry, rather than AtomID
As the LedgerEntryStoreView already has a precedent of returning LedgerEntry (no new imports), I feel it makes the most sense to add the new method getNextCommittedLedgerEntries, in the spirit of the existing method getNextCommitted, but returning LedgerEntry rather than AtomID. (Is it just me or is anyone else blah on AID plural being AIDs?)

I have a PR that implements this new method along with a new integration test that ensures the correct functionality that I will be attaching shortly.