### PR TITLE
Infrastructure/rpn1 246 liveness 1 timeout 2

### DIFF
--- a/radixdlt/src/integration/java/com/radixdlt/consensus/deterministic/ControlledNetwork.java
+++ b/radixdlt/src/integration/java/com/radixdlt/consensus/deterministic/ControlledNetwork.java
@@ -295,7 +295,7 @@ public final class ControlledNetwork {
 		}
 
 		private MessageRank messageRank(Proposal proposal) {
-			return new MessageRank(proposal.getEpoch(), proposal.getQC().getProposed().getView().number());
+			return new MessageRank(proposal.getEpoch(), proposal.getVertex().getView().number());
 		}
 
 		private MessageRank messageRank(VertexMetadata metadata, long viewIncrement) {

--- a/radixdlt/src/integration/java/com/radixdlt/consensus/deterministic/ControlledNetwork.java
+++ b/radixdlt/src/integration/java/com/radixdlt/consensus/deterministic/ControlledNetwork.java
@@ -49,11 +49,9 @@ import java.util.stream.Collectors;
  * This class is not thread safe.
  */
 public final class ControlledNetwork {
-	private final ImmutableList<ECPublicKey> nodes;
 	private final ImmutableMap<ChannelId, LinkedList<ControlledMessage>> messageQueue;
 
 	ControlledNetwork(ImmutableList<ECPublicKey> nodes) {
-		this.nodes = nodes;
 		this.messageQueue = nodes.stream()
 			.flatMap(n0 -> nodes.stream().map(n1 -> new ChannelId(n0, n1)))
 			.collect(

--- a/radixdlt/src/integration/java/com/radixdlt/consensus/deterministic/ControlledNode.java
+++ b/radixdlt/src/integration/java/com/radixdlt/consensus/deterministic/ControlledNode.java
@@ -90,7 +90,7 @@ class ControlledNode {
 		SyncVerticesRPCSender syncVerticesRPCSender = (syncAndTimeout != SyncAndTimeout.NONE)
 			? sender
 			: UnsupportedSyncVerticesRPCSender.INSTANCE;
-		LocalTimeoutSender localTimeoutSender = (syncAndTimeout == SyncAndTimeout.SYNC_AND_TIMEOUT) ? sender : (v, t) -> {};
+		LocalTimeoutSender localTimeoutSender = (syncAndTimeout == SyncAndTimeout.SYNC_AND_TIMEOUT) ? sender : (v, t) -> { };
 		Mempool mempool = new EmptyMempool();
 		Hasher nullHasher = data -> Hash.ZERO_HASH;
 		Hasher defaultHasher = new DefaultHasher();

--- a/radixdlt/src/integration/java/com/radixdlt/consensus/deterministic/ControlledNode.java
+++ b/radixdlt/src/integration/java/com/radixdlt/consensus/deterministic/ControlledNode.java
@@ -17,8 +17,6 @@
 
 package com.radixdlt.consensus.deterministic;
 
-import static org.mockito.Mockito.mock;
-
 import com.radixdlt.consensus.BFTEventReducer;
 import com.radixdlt.consensus.BFTFactory;
 import com.radixdlt.consensus.CommittedStateSync;
@@ -35,6 +33,8 @@ import com.radixdlt.consensus.ProposerElectionFactory;
 import com.radixdlt.consensus.VertexMetadata;
 import com.radixdlt.consensus.bft.VertexStore.GetVerticesRequest;
 import com.radixdlt.consensus.Hasher;
+import com.radixdlt.consensus.HashSigner;
+import com.radixdlt.consensus.HashVerifier;
 import com.radixdlt.consensus.SyncedStateComputer;
 import com.radixdlt.consensus.bft.VertexStore;
 import com.radixdlt.consensus.SyncVerticesRPCSender;
@@ -42,14 +42,15 @@ import com.radixdlt.consensus.VertexStoreFactory;
 import com.radixdlt.consensus.deterministic.ControlledNetwork.ControlledSender;
 import com.radixdlt.consensus.deterministic.configuration.UnsupportedSyncVerticesRPCSender;
 import com.radixdlt.consensus.liveness.FixedTimeoutPacemaker;
+import com.radixdlt.consensus.liveness.LocalTimeoutSender;
 import com.radixdlt.consensus.liveness.MempoolProposalGenerator;
 import com.radixdlt.consensus.liveness.ProposalGenerator;
-import com.radixdlt.consensus.liveness.ScheduledTimeoutSender;
 import com.radixdlt.consensus.safety.SafetyRules;
 import com.radixdlt.consensus.safety.SafetyState;
 import com.radixdlt.consensus.validators.ValidatorSet;
 import com.radixdlt.counters.SystemCounters;
 import com.radixdlt.counters.SystemCountersImpl;
+import com.radixdlt.crypto.ECDSASignature;
 import com.radixdlt.crypto.ECKeyPair;
 import com.radixdlt.crypto.Hash;
 import com.radixdlt.mempool.EmptyMempool;
@@ -67,30 +68,42 @@ class ControlledNode {
 	private final ValidatorSet initialValidatorSet;
 	private final ControlledSender controlledSender;
 
+	public enum SyncAndTimeout {
+		NONE,
+		SYNC,
+		SYNC_AND_TIMEOUT
+	}
+
 	ControlledNode(
 		String name,
 		ECKeyPair key,
 		ControlledSender sender,
 		ProposerElectionFactory proposerElectionFactory,
 		ValidatorSet initialValidatorSet,
-		boolean enableGetVerticesRPC,
+		SyncAndTimeout syncAndTimeout,
 		SyncedStateComputer<CommittedAtom> stateComputer
 	) {
 		this.systemCounters = new SystemCountersImpl();
 		this.controlledSender = Objects.requireNonNull(sender);
 		this.initialValidatorSet = Objects.requireNonNull(initialValidatorSet);
 
-
-		SyncVerticesRPCSender syncVerticesRPCSender = enableGetVerticesRPC ? sender : UnsupportedSyncVerticesRPCSender.INSTANCE;
+		SyncVerticesRPCSender syncVerticesRPCSender = (syncAndTimeout != SyncAndTimeout.NONE)
+			? sender
+			: UnsupportedSyncVerticesRPCSender.INSTANCE;
+		LocalTimeoutSender localTimeoutSender = (syncAndTimeout == SyncAndTimeout.SYNC_AND_TIMEOUT) ? sender : (v, t) -> {};
 		Mempool mempool = new EmptyMempool();
-		Hasher hasher = new DefaultHasher();
+		Hasher nullHasher = data -> Hash.ZERO_HASH;
+		Hasher defaultHasher = new DefaultHasher();
+		HashSigner nullSigner = (k, h) -> new ECDSASignature();
+		HashVerifier nullVerifier = (p, h, s) -> true;
 		VertexStoreFactory vertexStoreFactory = (vertex, qc, syncedStateComputer) ->
 			new VertexStore(vertex, qc, syncedStateComputer, syncVerticesRPCSender, sender, systemCounters);
 		BFTFactory bftFactory =
 			(endOfEpochSender, pacemaker, vertexStore, proposerElection, validatorSet) -> {
 				final ProposalGenerator proposalGenerator = new MempoolProposalGenerator(vertexStore, mempool);
-				final SafetyRules safetyRules = new SafetyRules(key, SafetyState.initialState(), hasher);
-				final PendingVotes pendingVotes = new PendingVotes(hasher);
+				final SafetyRules safetyRules = new SafetyRules(key, SafetyState.initialState(), nullHasher, nullSigner);
+				// PendingVotes needs a hasher that produces unique values, as it indexes by hash
+				final PendingVotes pendingVotes = new PendingVotes(defaultHasher, nullVerifier);
 
 				return new BFTEventReducer(
 					proposalGenerator,
@@ -103,6 +116,7 @@ class ControlledNode {
 					pendingVotes,
 					proposerElection,
 					key,
+					nullSigner,
 					validatorSet,
 					systemCounters
 				);
@@ -112,8 +126,8 @@ class ControlledNode {
 			name,
 			stateComputer,
 			EmptySyncEpochsRPCSender.INSTANCE,
-			mock(ScheduledTimeoutSender.class),
-			timeoutSender -> new FixedTimeoutPacemaker(1, timeoutSender),
+			localTimeoutSender,
+			timeoutSender -> new FixedTimeoutPacemaker(1, timeoutSender, nullVerifier),
 			vertexStoreFactory,
 			proposerElectionFactory,
 			bftFactory,

--- a/radixdlt/src/integration/java/com/radixdlt/consensus/deterministic/DeterministicTest.java
+++ b/radixdlt/src/integration/java/com/radixdlt/consensus/deterministic/DeterministicTest.java
@@ -26,6 +26,7 @@ import com.radixdlt.consensus.SyncedStateComputer;
 import com.radixdlt.consensus.deterministic.ControlledNetwork.ChannelId;
 import com.radixdlt.consensus.deterministic.ControlledNetwork.ControlledMessage;
 import com.radixdlt.consensus.deterministic.ControlledNetwork.ControlledSender;
+import com.radixdlt.consensus.deterministic.ControlledNode.SyncAndTimeout;
 import com.radixdlt.consensus.deterministic.configuration.SingleEpochAlwaysSyncedStateComputer;
 import com.radixdlt.consensus.deterministic.configuration.SingleEpochFailOnSyncStateComputer;
 import com.radixdlt.consensus.deterministic.configuration.SingleEpochRandomlySyncedStateComputer;
@@ -44,6 +45,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -56,9 +58,11 @@ public final class DeterministicTest {
 	private final ImmutableList<ECPublicKey> pks;
 	private final ControlledNetwork network;
 
+
+
 	private DeterministicTest(
 		int numNodes,
-		boolean enableGetVerticesRPC,
+		SyncAndTimeout syncAndTimeout,
 		BiFunction<CommittedStateSyncSender, EpochChangeSender, SyncedStateComputer<CommittedAtom>> stateComputerSupplier
 	) {
 		ImmutableList<ECKeyPair> keys = Stream.generate(ECKeyPair::generateNew)
@@ -68,21 +72,21 @@ public final class DeterministicTest {
 		this.pks = keys.stream()
 			.map(ECKeyPair::getPublicKey)
 			.collect(ImmutableList.toImmutableList());
-		this.network = new ControlledNetwork(pks);
+		this.network = new ControlledNetwork();
 		ValidatorSet initialValidatorSet = ValidatorSet.from(
 			pks.stream().map(pk -> Validator.from(pk, UInt256.ONE)).collect(Collectors.toList())
 		);
 
 		this.nodes = Streams.mapWithIndex(keys.stream(),
 			(key, index) -> {
-				ControlledSender sender = network.getSender(key.getPublicKey());
+				ControlledSender sender = network.createSender(key.getPublicKey());
 				return new ControlledNode(
 					"node-" + index,
 					key,
 					sender,
 					vset -> new WeightedRotatingLeaders(vset, Comparator.comparing(v -> v.nodeKey().euid()), 5),
 					initialValidatorSet,
-					enableGetVerticesRPC,
+					syncAndTimeout,
 					stateComputerSupplier.apply(sender, sender)
 				);
 			})
@@ -98,7 +102,7 @@ public final class DeterministicTest {
 	public static DeterministicTest createSingleEpochRandomlySyncedTest(int numNodes, Random random) {
 		return new DeterministicTest(
 			numNodes,
-			true,
+			SyncAndTimeout.SYNC,
 			(committedSender, epochSender) -> new SingleEpochRandomlySyncedStateComputer(random, committedSender)
 		);
 	}
@@ -112,7 +116,21 @@ public final class DeterministicTest {
 	public static DeterministicTest createSingleEpochAlwaysSyncedTest(int numNodes) {
 		return new DeterministicTest(
 			numNodes,
-			true,
+			SyncAndTimeout.SYNC,
+			(committedSender, epochChangeSender) -> SingleEpochAlwaysSyncedStateComputer.INSTANCE
+		);
+	}
+
+	/**
+	 * Creates a new "always synced BFT with timeouts" Deterministic test solely on the bft layer,
+	 *
+	 * @param numNodes number of nodes in the network
+	 * @return a deterministic test
+	 */
+	public static DeterministicTest createSingleEpochAlwaysSyncedWithTimeoutsTest(int numNodes) {
+		return new DeterministicTest(
+			numNodes,
+			SyncAndTimeout.SYNC_AND_TIMEOUT,
 			(committedSender, epochChangeSender) -> SingleEpochAlwaysSyncedStateComputer.INSTANCE
 		);
 	}
@@ -128,7 +146,7 @@ public final class DeterministicTest {
 	public static DeterministicTest createSingleEpochFailOnSyncTest(int numNodes) {
 		return new DeterministicTest(
 			numNodes,
-			false,
+			SyncAndTimeout.NONE,
 			(committedSender, epochChangeSender) -> SingleEpochFailOnSyncStateComputer.INSTANCE
 		);
 	}
@@ -145,10 +163,25 @@ public final class DeterministicTest {
 	}
 
 	public void processNextMsg(Random random) {
-		processNextMsg(random, (c, m) -> true);
+		processNextMsgWithReceiver(random, (c, m) -> true);
 	}
 
-	public void processNextMsg(Random random, BiPredicate<Integer, Object> filter) {
+	public void processNextMsg(Random random, Predicate<Object> filter) {
+		List<ControlledMessage> possibleMsgs = network.peekNextMessages();
+		if (possibleMsgs.isEmpty()) {
+			throw new IllegalStateException("No messages available (Lost Responsiveness)");
+		}
+
+		int nextIndex =  random.nextInt(possibleMsgs.size());
+		ChannelId channelId = possibleMsgs.get(nextIndex).getChannelId();
+		Object msg = network.popNextMessage(channelId);
+		int receiverIndex = pks.indexOf(channelId.getReceiver());
+		if (filter.test(msg)) {
+			nodes.get(receiverIndex).processNext(msg);
+		}
+	}
+
+	public void processNextMsgWithReceiver(Random random, BiPredicate<Integer, Object> filter) {
 		List<ControlledMessage> possibleMsgs = network.peekNextMessages();
 		if (possibleMsgs.isEmpty()) {
 			throw new IllegalStateException("No messages available (Lost Responsiveness)");
@@ -159,6 +192,22 @@ public final class DeterministicTest {
 		Object msg = network.popNextMessage(channelId);
 		int receiverIndex = pks.indexOf(channelId.getReceiver());
 		if (filter.test(receiverIndex, msg)) {
+			nodes.get(receiverIndex).processNext(msg);
+		}
+	}
+
+	public void processNextMsgWithSenderAndReceiver(Random random, TriPredicate<Integer, Integer, Object> filter) {
+		List<ControlledMessage> possibleMsgs = network.peekNextMessages();
+		if (possibleMsgs.isEmpty()) {
+			throw new IllegalStateException("No messages available (Lost Responsiveness)");
+		}
+
+		int nextIndex =  random.nextInt(possibleMsgs.size());
+		ChannelId channelId = possibleMsgs.get(nextIndex).getChannelId();
+		Object msg = network.popNextMessage(channelId);
+		int receiverIndex = pks.indexOf(channelId.getReceiver());
+		int senderIndex = pks.indexOf(channelId.getSender());
+		if (filter.test(senderIndex, receiverIndex, msg)) {
 			nodes.get(receiverIndex).processNext(msg);
 		}
 	}

--- a/radixdlt/src/integration/java/com/radixdlt/consensus/deterministic/MessageQueue.java
+++ b/radixdlt/src/integration/java/com/radixdlt/consensus/deterministic/MessageQueue.java
@@ -1,0 +1,160 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package com.radixdlt.consensus.deterministic;
+
+import java.util.AbstractList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.radixdlt.consensus.deterministic.ControlledNetwork.ChannelId;
+import com.radixdlt.consensus.deterministic.ControlledNetwork.ControlledMessage;
+import com.radixdlt.consensus.deterministic.ControlledNetwork.EpochAndView;
+
+/**
+ * Queue for messages by view.
+ */
+final class MessageQueue {
+	// Should really be an AbstractSequentialList, but I don't really want to have
+	// to implement a ListIterator.  Performance seems adequate for now.
+	final class ArrayOfLinkedLists<T> extends AbstractList<T> {
+
+		private final Object[] lists;
+		private final int size;
+
+		ArrayOfLinkedLists(Collection<LinkedList<T>> lists) {
+			this.lists = lists.toArray();
+			int count = 0;
+			for (int i = 0; i < this.lists.length; ++i) {
+				count += list(i).size();
+			}
+			this.size = count;
+		}
+
+		@SuppressWarnings("unchecked")
+		private LinkedList<T> list(int i) {
+			return (LinkedList<T>) lists[i];
+		}
+
+		@Override
+		public T get(int index) {
+			int currentIndex = index;
+			for (int i = 0; i < this.lists.length; ++i) {
+				LinkedList<T> list = list(i);
+				int listSize = list.size();
+				if (currentIndex < listSize) {
+					return list.get(currentIndex);
+				} else {
+					currentIndex -= listSize;
+				}
+			}
+			throw new ArrayIndexOutOfBoundsException(index);
+		}
+
+		@Override
+		public int size() {
+			return this.size;
+		}
+	}
+
+	private final HashMap<EpochAndView, HashMap<ChannelId, LinkedList<ControlledMessage>>> messageQueue = Maps.newHashMap();
+	private EpochAndView minimumEpochAndView = null; // Cached minimum view
+
+	MessageQueue() {
+		// Nothing here for now
+	}
+
+	void add(EpochAndView eav, ControlledMessage item) {
+		this.messageQueue.computeIfAbsent(eav, k -> Maps.newHashMap()).computeIfAbsent(item.getChannelId(), k -> Lists.newLinkedList()).add(item);
+		if (this.minimumEpochAndView == null || eav.compareTo(this.minimumEpochAndView) < 0) {
+			this.minimumEpochAndView = eav;
+		}
+	}
+
+	ControlledMessage pop(ChannelId channelId) {
+		HashMap<ChannelId, LinkedList<ControlledMessage>> msgMap = this.messageQueue.get(this.minimumEpochAndView);
+		if (msgMap == null) {
+			return painfulPop(channelId);
+		}
+		LinkedList<ControlledMessage> msgs = msgMap.get(channelId);
+		if (msgs == null) {
+			return painfulPop(channelId);
+		}
+		ControlledMessage item = msgs.pop();
+		if (msgs.isEmpty()) {
+			msgMap.remove(channelId);
+			if (msgMap.isEmpty()) {
+				this.messageQueue.remove(this.minimumEpochAndView);
+				this.minimumEpochAndView = minimumKey(this.messageQueue.keySet());
+			}
+		}
+		return item;
+	}
+
+	// Really only here to work with processNextMsg(int, int, Class<?>) in BFTDeterministicTest
+	private ControlledMessage painfulPop(ChannelId channelId) {
+		List<Map.Entry<EpochAndView, HashMap<ChannelId, LinkedList<ControlledMessage>>>> entries = Lists.newArrayList(this.messageQueue.entrySet());
+		Collections.sort(entries, Map.Entry.comparingByKey());
+		for (Map.Entry<EpochAndView, HashMap<ChannelId, LinkedList<ControlledMessage>>> entry : entries) {
+			HashMap<ChannelId, LinkedList<ControlledMessage>> msgMap = entry.getValue();
+			LinkedList<ControlledMessage> msgs = msgMap.get(channelId);
+			if (msgs != null) {
+				ControlledMessage item = msgs.pop();
+				if (msgs.isEmpty()) {
+					msgMap.remove(channelId);
+					if (msgMap.isEmpty()) {
+						this.messageQueue.remove(entry.getKey());
+						// Can't affect minimumView if we are here
+					}
+				}
+				return item;
+			}
+		}
+		throw new NoSuchElementException();
+	}
+
+	List<ControlledMessage> lowestViewMessages() {
+		if (this.messageQueue.isEmpty()) {
+			return Collections.emptyList();
+		}
+		return new ArrayOfLinkedLists<>(this.messageQueue.get(this.minimumEpochAndView).values());
+	}
+
+	@Override
+	public String toString() {
+		return this.messageQueue.toString();
+	}
+
+	// Believe it or not, this is faster, when coupled with minimumView
+	// caching, than using a TreeMap for nodes == 100.
+	private static EpochAndView minimumKey(Set<EpochAndView> eavs) {
+		if (eavs.isEmpty()) {
+			return null;
+		}
+		List<EpochAndView> views = Lists.newArrayList(eavs);
+		Collections.sort(views);
+		return views.get(0);
+	}
+}

--- a/radixdlt/src/integration/java/com/radixdlt/consensus/deterministic/MessageQueue.java
+++ b/radixdlt/src/integration/java/com/radixdlt/consensus/deterministic/MessageQueue.java
@@ -17,9 +17,11 @@
 
 package com.radixdlt.consensus.deterministic;
 
+import java.io.PrintStream;
 import java.util.AbstractList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -32,6 +34,7 @@ import com.google.common.collect.Maps;
 import com.radixdlt.consensus.deterministic.ControlledNetwork.ChannelId;
 import com.radixdlt.consensus.deterministic.ControlledNetwork.ControlledMessage;
 import com.radixdlt.consensus.deterministic.ControlledNetwork.MessageRank;
+import com.radixdlt.identifiers.EUID;
 
 /**
  * Queue for messages by view.
@@ -156,5 +159,22 @@ final class MessageQueue {
 		List<MessageRank> views = Lists.newArrayList(eavs);
 		Collections.sort(views);
 		return views.get(0);
+	}
+
+	void dump(PrintStream out) {
+		Comparator<ChannelId> channelIdComparator = Comparator
+			.<ChannelId, EUID>comparing(chid -> chid.getSender().euid())
+			.thenComparing(chid -> chid.getReceiver().euid());
+		out.format("%s {%n", this.messageQueue);
+		this.messageQueue.entrySet().stream()
+			.sorted(Map.Entry.comparingByKey())
+			.forEachOrdered(e1 -> {
+				out.format("    %s {%n", e1.getKey());
+				e1.getValue().entrySet().stream()
+					.sorted(Map.Entry.comparingByKey(channelIdComparator))
+					.forEach(e2 -> out.format("        %s: %s%n", e2.getKey(), e2.getValue()));
+				out.println("    }");
+			});
+		out.println("}");
 	}
 }

--- a/radixdlt/src/integration/java/com/radixdlt/consensus/deterministic/TriPredicate.java
+++ b/radixdlt/src/integration/java/com/radixdlt/consensus/deterministic/TriPredicate.java
@@ -1,0 +1,72 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package com.radixdlt.consensus.deterministic;
+
+import java.util.Objects;
+import java.util.function.BiPredicate;
+
+/**
+ * Represents a predicate (boolean-valued function) of three arguments.  This is
+ * the three-arity specialisation of {@link Predicate}.
+ *
+ * @param <T> the type of the first argument to the predicate
+ * @param <U> the type of the second argument the predicate
+ * @param <V> the type of the second argument the predicate
+ *
+ * @see Predicate
+ * @see BiPredicate
+ */
+@FunctionalInterface
+public interface TriPredicate<T, U, V> {
+
+    /**
+     * Evaluates this predicate on the specified arguments.
+     *
+     * @param t the first input argument
+     * @param u the second input argument
+     * @param v the third input argument
+     * @return {@code true} if the input arguments match the predicate, otherwise {@code false}
+     */
+    boolean test(T t, U u, V v);
+
+    default TriPredicate<T, U, V> and(TriPredicate<? super T, ? super U, ? super V> other) {
+        Objects.requireNonNull(other);
+        return (T t, U u, V v) -> test(t, u, v) && other.test(t, u, v);
+    }
+
+    default TriPredicate<T, U, V> negate() {
+        return (T t, U u, V v) -> !test(t, u, v);
+    }
+
+    default TriPredicate<T, U, V> or(TriPredicate<? super T, ? super U, ? super V> other) {
+        Objects.requireNonNull(other);
+        return (T t, U u, V v) -> test(t, u, v) || other.test(t, u, v);
+    }
+
+    default BiPredicate<U, V> bindFirst(T t) {
+    	return (U u, V v) -> test(t, u, v);
+    }
+
+    default BiPredicate<T, V> bindSecond(U u) {
+    	return (T t, V v) -> test(t, u, v);
+    }
+
+    default BiPredicate<T, U> bindThird(V v) {
+    	return (T t, U u) -> test(t, u, v);
+    }
+}

--- a/radixdlt/src/integration/java/com/radixdlt/consensus/deterministic/tests/bft/synchronous/FProposalDropperResponsiveTest.java
+++ b/radixdlt/src/integration/java/com/radixdlt/consensus/deterministic/tests/bft/synchronous/FProposalDropperResponsiveTest.java
@@ -43,7 +43,7 @@ public class FProposalDropperResponsiveTest {
 		final DeterministicTest test = DeterministicTest.createSingleEpochAlwaysSyncedTest(numNodes);
 		test.start();
 		for (int step = 0; step < NUM_STEPS; step++) {
-			test.processNextMsg(random, (receiverId, msg) -> {
+			test.processNextMsgWithReceiver(random, (receiverId, msg) -> {
 				if (msg instanceof Proposal) {
 					final Proposal proposal = (Proposal) msg;
 					final View view = proposal.getVertex().getView();

--- a/radixdlt/src/integration/java/com/radixdlt/consensus/deterministic/tests/bft/synchronous/OneProposalDropperResponsiveTest.java
+++ b/radixdlt/src/integration/java/com/radixdlt/consensus/deterministic/tests/bft/synchronous/OneProposalDropperResponsiveTest.java
@@ -38,7 +38,7 @@ public class OneProposalDropperResponsiveTest {
 		final DeterministicTest test = DeterministicTest.createSingleEpochAlwaysSyncedTest(numNodes);
 		test.start();
 		for (int step = 0; step < NUM_STEPS; step++) {
-			test.processNextMsg(random, (receiverId, msg) -> {
+			test.processNextMsgWithReceiver(random, (receiverId, msg) -> {
 				if (msg instanceof Proposal) {
 					final Proposal proposal = (Proposal) msg;
 					final View view = proposal.getVertex().getView();

--- a/radixdlt/src/integration/java/com/radixdlt/consensus/deterministic/tests/bft/synchronous/OneProposalTimeoutResponsiveTest.java
+++ b/radixdlt/src/integration/java/com/radixdlt/consensus/deterministic/tests/bft/synchronous/OneProposalTimeoutResponsiveTest.java
@@ -55,10 +55,11 @@ public class OneProposalTimeoutResponsiveTest {
 			SystemCounters counters = test.getSystemCounters(nodeIndex);
 			long numberOfIndirectParents = counters.get(SystemCounters.CounterType.CONSENSUS_INDIRECT_PARENT);
 			long numberOfTimeouts = counters.get(SystemCounters.CounterType.CONSENSUS_TIMEOUT);
-			// FIXME: Checks should be exact, but issues with synchronisation prevent this
-			// FIXME: Indirect parents received through sync don't seem to be included in the indirect parents count
-			assertThat(numberOfIndirectParents).isBetween(minRange(requiredIndirectParents, 10), maxRange(requiredIndirectParents, 10));
-			assertThat(numberOfTimeouts).isGreaterThanOrEqualTo(requiredTimeouts);
+			assertThat(numberOfIndirectParents).isEqualTo(requiredIndirectParents);
+			// Not every node will timeout on a dropped proposal, as 2f+1 nodes will timeout and then continue.
+			// The remaining f nodes will sync rather than timing out.
+			// The lower bound of the following test is likely to pass, but not guaranteed by anything here.
+			assertThat(numberOfTimeouts).isBetween(1L, requiredTimeouts);
 		}
 	}
 
@@ -94,18 +95,5 @@ public class OneProposalTimeoutResponsiveTest {
 	public void when_run_100_correct_nodes_with_1_timeout__then_bft_should_be_responsive() {
 		// FIXME: Could increase frequency once sync issues resolved.
 		this.run(100, 30_000, 1000);
-	}
-
-
-	private static long minRange(long n, int percent) {
-		return n - percentage(n, percent);
-	}
-
-	private static long maxRange(long n, int percent) {
-		return n + percentage(n, percent);
-	}
-
-	private static long percentage(long n, int percent) {
-		return n * 100L / percent;
 	}
 }

--- a/radixdlt/src/integration/java/com/radixdlt/consensus/deterministic/tests/bft/synchronous/OneProposalTimeoutResponsiveTest.java
+++ b/radixdlt/src/integration/java/com/radixdlt/consensus/deterministic/tests/bft/synchronous/OneProposalTimeoutResponsiveTest.java
@@ -1,0 +1,111 @@
+/*
+ *
+ *  * (C) Copyright 2020 Radix DLT Ltd
+ *  *
+ *  * Radix DLT Ltd licenses this file to you under the Apache License,
+ *  * Version 2.0 (the "License"); you may not use this file except in
+ *  * compliance with the License.  You may obtain a copy of the
+ *  * License at
+ *  *
+ *  *  http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing,
+ *  * software distributed under the License is distributed on an
+ *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *  * either express or implied.  See the License for the specific
+ *  * language governing permissions and limitations under the License.
+ *
+ */
+
+package com.radixdlt.consensus.deterministic.tests.bft.synchronous;
+
+import java.util.Random;
+import java.util.Set;
+
+import org.assertj.core.util.Sets;
+import org.junit.Test;
+
+import com.radixdlt.consensus.NewView;
+import com.radixdlt.consensus.Proposal;
+import com.radixdlt.consensus.View;
+import com.radixdlt.consensus.deterministic.DeterministicTest;
+import com.radixdlt.counters.SystemCounters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OneProposalTimeoutResponsiveTest {
+	private final Random random = new Random(123456);
+	private final Set<Integer> nodesCompleted = Sets.newHashSet();
+
+	private void run(int numNodes, long numViews, long dropPeriod) {
+		final DeterministicTest test = DeterministicTest.createSingleEpochAlwaysSyncedWithTimeoutsTest(numNodes);
+		test.start();
+
+		nodesCompleted.clear();
+		while (nodesCompleted.size() < numNodes) {
+			test.processNextMsgWithSenderAndReceiver(
+				random,
+				(senderId, receiverId, msg) -> processMessage(senderId, msg, numViews, dropPeriod));
+		}
+
+		long requiredIndirectParents = (numViews - 1) / dropPeriod; // Edge case if dropPeriod a factor of numViews
+		long requiredTimeouts = numViews / dropPeriod;
+
+		for (int nodeIndex = 0; nodeIndex < numNodes; ++nodeIndex) {
+			SystemCounters counters = test.getSystemCounters(nodeIndex);
+			long numberOfIndirectParents = counters.get(SystemCounters.CounterType.CONSENSUS_INDIRECT_PARENT);
+			long numberOfTimeouts = counters.get(SystemCounters.CounterType.CONSENSUS_TIMEOUT);
+			// FIXME: Checks should be exact, but issues with synchronisation prevent this
+			// FIXME: Indirect parents received through sync don't seem to be included in the indirect parents count
+			assertThat(numberOfIndirectParents).isBetween(minRange(requiredIndirectParents, 10), maxRange(requiredIndirectParents, 10));
+			assertThat(numberOfTimeouts).isGreaterThanOrEqualTo(requiredTimeouts);
+		}
+	}
+
+	private boolean processMessage(int senderId, Object msg, long numViews, long dropPeriod) {
+		if (msg instanceof NewView) {
+			NewView nv = (NewView) msg;
+			if (nv.getView().number() > numViews) {
+				this.nodesCompleted.add(senderId);
+				return false;
+			}
+		}
+		if (msg instanceof Proposal) {
+			final Proposal proposal = (Proposal) msg;
+			final View view = proposal.getVertex().getView();
+			final long viewNumber = view.number();
+
+			return viewNumber % dropPeriod != 0;
+		}
+		return true;
+	}
+
+	@Test
+	public void when_run_3_correct_nodes_with_1_timeout__then_bft_should_be_responsive() {
+		this.run(3, 300_000, 100);
+	}
+
+	@Test
+	public void when_run_4_correct_nodes_with_1_timeout__then_bft_should_be_responsive() {
+		this.run(4, 300_000, 100);
+	}
+
+	@Test
+	public void when_run_100_correct_nodes_with_1_timeout__then_bft_should_be_responsive() {
+		// FIXME: Could increase frequency once sync issues resolved.
+		this.run(100, 30_000, 1000);
+	}
+
+
+	private static long minRange(long n, int percent) {
+		return n - percentage(n, percent);
+	}
+
+	private static long maxRange(long n, int percent) {
+		return n + percentage(n, percent);
+	}
+
+	private static long percentage(long n, int percent) {
+		return n * 100L / percent;
+	}
+}

--- a/radixdlt/src/integration/java/com/radixdlt/consensus/deterministic/tests/ledger/FProposalDropperRandomSyncResponsiveTest.java
+++ b/radixdlt/src/integration/java/com/radixdlt/consensus/deterministic/tests/ledger/FProposalDropperRandomSyncResponsiveTest.java
@@ -43,7 +43,7 @@ public class FProposalDropperRandomSyncResponsiveTest {
 		final DeterministicTest test = DeterministicTest.createSingleEpochRandomlySyncedTest(numNodes, random);
 		test.start();
 		for (int step = 0; step < NUM_STEPS; step++) {
-			test.processNextMsg(random, (receiverId, msg) -> {
+			test.processNextMsgWithReceiver(random, (receiverId, msg) -> {
 				if (msg instanceof Proposal) {
 					final Proposal proposal = (Proposal) msg;
 					final View view = proposal.getVertex().getView();

--- a/radixdlt/src/integration/java/com/radixdlt/consensus/deterministic/tests/ledger/OneProposalDropperRandomSyncResponsiveTest.java
+++ b/radixdlt/src/integration/java/com/radixdlt/consensus/deterministic/tests/ledger/OneProposalDropperRandomSyncResponsiveTest.java
@@ -38,7 +38,7 @@ public class OneProposalDropperRandomSyncResponsiveTest {
 		final DeterministicTest test = DeterministicTest.createSingleEpochRandomlySyncedTest(numNodes, random);
 		test.start();
 		for (int step = 0; step < NUM_STEPS; step++) {
-			test.processNextMsg(random, (receiverId, msg) -> {
+			test.processNextMsgWithReceiver(random, (receiverId, msg) -> {
 				if (msg instanceof Proposal) {
 					final Proposal proposal = (Proposal) msg;
 					final View view = proposal.getVertex().getView();

--- a/radixdlt/src/integration/java/com/radixdlt/consensus/simulation/tests/epochs/MovingWindowValidatorsTest.java
+++ b/radixdlt/src/integration/java/com/radixdlt/consensus/simulation/tests/epochs/MovingWindowValidatorsTest.java
@@ -29,7 +29,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 import org.assertj.core.api.AssertionsForClassTypes;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class MovingWindowValidatorsTest {
@@ -44,7 +43,6 @@ public class MovingWindowValidatorsTest {
 	}
 
 	@Test
-	@Ignore("Ignore until Travis issue resolved")
 	public void given_correct_1_node_bft_with_4_total_nodes_with_changing_epochs_per_100_views__then_should_pass_bft_and_epoch_invariants() {
 		SimulationTest bftTest = bftTestBuilder
 			.pacemakerTimeout(5000)
@@ -71,7 +69,6 @@ public class MovingWindowValidatorsTest {
 	}
 
 	@Test
-	@Ignore("Ignore until Travis issue resolved")
 	public void given_correct_25_node_bft_with_50_total_nodes_with_changing_epochs_per_100_views__then_should_pass_bft_and_epoch_invariants() {
 		SimulationTest bftTest = bftTestBuilder
 			.numNodes(100)
@@ -86,7 +83,6 @@ public class MovingWindowValidatorsTest {
 	}
 
 	@Test
-	@Ignore("Ignore until Travis issue resolved")
 	public void given_correct_25_node_bft_with_50_total_nodes_with_changing_epochs_per_1_view__then_should_pass_bft_and_epoch_invariants() {
 		SimulationTest bftTest = bftTestBuilder
 			.numNodes(100)

--- a/radixdlt/src/integration/java/com/radixdlt/consensus/simulation/tests/epochs/RandomValidatorsTest.java
+++ b/radixdlt/src/integration/java/com/radixdlt/consensus/simulation/tests/epochs/RandomValidatorsTest.java
@@ -85,7 +85,7 @@ public class RandomValidatorsTest {
 			.epochToNodesMapper(badRandomEpochToNodesMapper())
 			.build();
 		Map<String, Optional<TestInvariantError>> results = bftTest.run(1, TimeUnit.MINUTES);
-		assertThat(results).hasValueSatisfying(new Condition<Optional>(Optional::isPresent, "Has error"));
+		assertThat(results).hasValueSatisfying(new Condition<>(Optional::isPresent, "Has error"));
 	}
 
 }

--- a/radixdlt/src/main/java/com/radixdlt/CerberusModule.java
+++ b/radixdlt/src/main/java/com/radixdlt/CerberusModule.java
@@ -86,6 +86,9 @@ public class CerberusModule extends AbstractModule {
 
 	@Override
 	protected void configure() {
+		// Signing
+		bind(HashSigner.class).toInstance(ECKeyPair::sign);
+
 		// Timed local messages
 		bind(PacemakerRx.class).to(ScheduledLocalTimeoutSender.class);
 		bind(LocalTimeoutSender.class).to(ScheduledLocalTimeoutSender.class);

--- a/radixdlt/src/main/java/com/radixdlt/CerberusModule.java
+++ b/radixdlt/src/main/java/com/radixdlt/CerberusModule.java
@@ -74,12 +74,7 @@ import java.util.Objects;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 public class CerberusModule extends AbstractModule {
-	private static final Logger log = LogManager.getLogger("Startup");
-
 	private final RuntimeProperties runtimeProperties;
 
 	public CerberusModule(RuntimeProperties runtimeProperties) {

--- a/radixdlt/src/main/java/com/radixdlt/CerberusModule.java
+++ b/radixdlt/src/main/java/com/radixdlt/CerberusModule.java
@@ -38,6 +38,7 @@ import com.radixdlt.consensus.SyncEpochsRPCSender;
 import com.radixdlt.consensus.SyncedStateComputer;
 import com.radixdlt.consensus.VertexStoreEventsRx;
 import com.radixdlt.consensus.InternalMessagePasser;
+import com.radixdlt.consensus.HashSigner;
 import com.radixdlt.consensus.ProposerElectionFactory;
 import com.radixdlt.consensus.Hasher;
 import com.radixdlt.consensus.SyncVerticesRPCRx;
@@ -47,11 +48,12 @@ import com.radixdlt.consensus.SyncVerticesRPCSender;
 import com.radixdlt.consensus.VertexStoreFactory;
 import com.radixdlt.consensus.View;
 import com.radixdlt.consensus.liveness.FixedTimeoutPacemaker;
+import com.radixdlt.consensus.liveness.LocalTimeoutSender;
 import com.radixdlt.consensus.liveness.MempoolProposalGenerator;
 import com.radixdlt.consensus.liveness.PacemakerFactory;
 import com.radixdlt.consensus.liveness.PacemakerRx;
 import com.radixdlt.consensus.liveness.ProposalGenerator;
-import com.radixdlt.consensus.liveness.ScheduledTimeoutSender;
+import com.radixdlt.consensus.liveness.ScheduledLocalTimeoutSender;
 import com.radixdlt.consensus.liveness.WeightedRotatingLeaders;
 import com.radixdlt.consensus.safety.SafetyRules;
 import com.radixdlt.consensus.safety.SafetyState;
@@ -60,6 +62,7 @@ import com.radixdlt.consensus.sync.SyncedRadixEngine;
 import com.radixdlt.consensus.sync.SyncedRadixEngine.CommittedStateSyncSender;
 import com.radixdlt.counters.SystemCounters;
 import com.radixdlt.crypto.ECKeyPair;
+import com.radixdlt.crypto.ECPublicKey;
 import com.radixdlt.engine.RadixEngine;
 import com.radixdlt.mempool.Mempool;
 import com.radixdlt.middleware2.LedgerAtom;
@@ -84,7 +87,8 @@ public class CerberusModule extends AbstractModule {
 	@Override
 	protected void configure() {
 		// Timed local messages
-		bind(PacemakerRx.class).to(ScheduledTimeoutSender.class);
+		bind(PacemakerRx.class).to(ScheduledLocalTimeoutSender.class);
+		bind(LocalTimeoutSender.class).to(ScheduledLocalTimeoutSender.class);
 
 		// Local messages
 		bind(VertexStoreEventsRx.class).to(InternalMessagePasser.class);
@@ -119,6 +123,7 @@ public class CerberusModule extends AbstractModule {
 		Mempool mempool,
 		@Named("self") ECKeyPair selfKey,
 		Hasher hasher,
+		HashSigner signer,
 		SystemCounters counters
 	) {
 		return (
@@ -129,8 +134,8 @@ public class CerberusModule extends AbstractModule {
 			validatorSet
 		) -> {
 			final ProposalGenerator proposalGenerator = new MempoolProposalGenerator(vertexStore, mempool);
-			final SafetyRules safetyRules = new SafetyRules(selfKey, SafetyState.initialState(), hasher);
-			final PendingVotes pendingVotes = new PendingVotes(hasher);
+			final SafetyRules safetyRules = new SafetyRules(selfKey, SafetyState.initialState(), hasher, signer);
+			final PendingVotes pendingVotes = new PendingVotes(hasher, ECPublicKey::verify);
 
 			return new BFTEventReducer(
 				proposalGenerator,
@@ -143,6 +148,7 @@ public class CerberusModule extends AbstractModule {
 				pendingVotes,
 				proposerElection,
 				selfKey,
+				signer,
 				validatorSet,
 				counters
 			);
@@ -155,7 +161,7 @@ public class CerberusModule extends AbstractModule {
 		SyncedRadixEngine syncedRadixEngine,
 		BFTFactory bftFactory,
 		SyncEpochsRPCSender syncEpochsRPCSender,
-		ScheduledTimeoutSender scheduledTimeoutSender,
+		LocalTimeoutSender scheduledTimeoutSender,
 		PacemakerFactory pacemakerFactory,
 		VertexStoreFactory vertexStoreFactory,
 		ProposerElectionFactory proposerElectionFactory,
@@ -254,16 +260,16 @@ public class CerberusModule extends AbstractModule {
 
 	@Provides
 	@Singleton
-	private ScheduledTimeoutSender timeoutSender() {
+	private ScheduledLocalTimeoutSender timeoutSender() {
 		ScheduledExecutorService ses = Executors.newSingleThreadScheduledExecutor(ThreadFactories.daemonThreads("TimeoutSender"));
-		return new ScheduledTimeoutSender(ses);
+		return new ScheduledLocalTimeoutSender(ses);
 	}
 
 	@Provides
 	@Singleton
 	private PacemakerFactory pacemakerFactory() {
 		final int pacemakerTimeout = runtimeProperties.get("consensus.pacemaker_timeout_millis", 5000);
-		return timeoutSender -> new FixedTimeoutPacemaker(pacemakerTimeout, timeoutSender);
+		return timeoutSender -> new FixedTimeoutPacemaker(pacemakerTimeout, timeoutSender, ECPublicKey::verify);
 	}
 
 	@Provides

--- a/radixdlt/src/main/java/com/radixdlt/consensus/BFTEventPreprocessor.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/BFTEventPreprocessor.java
@@ -98,7 +98,7 @@ public final class BFTEventPreprocessor implements BFTEventProcessor {
 	 */
 	@Override
 	public void processLocalSync(Hash vertexId) {
-		log.info("{}: LOCAL_SYNC: {}", this.getShortName(), vertexId);
+		log.trace("{}: LOCAL_SYNC: {}", this.getShortName(), vertexId);
 		for (SyncQueue queue : queues.getQueues()) {
 			if (peekAndExecute(queue, vertexId)) {
 				queue.pop();
@@ -159,7 +159,7 @@ public final class BFTEventPreprocessor implements BFTEventProcessor {
 		log.trace("{}: NEW_VIEW: Queueing {}", this.getShortName(), newView);
 		if (queues.isEmptyElseAdd(newView)) {
 			if (!processNewViewInternal(newView)) {
-				log.info("{}: NEW_VIEW: Queuing {} Waiting for Sync", getShortName(), newView);
+				log.debug("{}: NEW_VIEW: Queuing {} Waiting for Sync", getShortName(), newView);
 				queues.add(newView);
 			}
 		}
@@ -189,7 +189,7 @@ public final class BFTEventPreprocessor implements BFTEventProcessor {
 		log.trace("{}: PROPOSAL: Queueing {}", this.getShortName(), proposal);
 		if (queues.isEmptyElseAdd(proposal)) {
 			if (!processProposalInternal(proposal)) {
-				log.info("{}: PROPOSAL: Queuing {} Waiting for Sync", getShortName(), proposal);
+				log.debug("{}: PROPOSAL: Queuing {} Waiting for Sync", getShortName(), proposal);
 				queues.add(proposal);
 			}
 		}

--- a/radixdlt/src/main/java/com/radixdlt/consensus/BFTEventReducer.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/BFTEventReducer.java
@@ -222,10 +222,6 @@ public final class BFTEventReducer implements BFTEventProcessor {
 			return;
 		}
 
-		if (!proposedVertex.hasDirectParent()) {
-			counters.increment(CounterType.CONSENSUS_INDIRECT_PARENT);
-		}
-
 		final VertexMetadata vertexMetadata;
 		try {
 			vertexMetadata = vertexStore.insertVertex(proposedVertex);

--- a/radixdlt/src/main/java/com/radixdlt/consensus/BFTEventReducer.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/BFTEventReducer.java
@@ -65,6 +65,7 @@ public final class BFTEventReducer implements BFTEventProcessor {
 	private final Pacemaker pacemaker;
 	private final ProposerElection proposerElection;
 	private final ECKeyPair selfKey; // TODO remove signing/address to separate identity management
+	private final HashSigner signer; // TODO remove signing/address to separate identity management
 	private final SafetyRules safetyRules;
 	private final ValidatorSet validatorSet;
 	private final SystemCounters counters;
@@ -87,6 +88,7 @@ public final class BFTEventReducer implements BFTEventProcessor {
 		PendingVotes pendingVotes,
 		ProposerElection proposerElection,
 		@Named("self") ECKeyPair selfKey,
+		HashSigner signer,
 		ValidatorSet validatorSet,
 		SystemCounters counters
 	) {
@@ -100,6 +102,7 @@ public final class BFTEventReducer implements BFTEventProcessor {
 		this.pendingVotes = Objects.requireNonNull(pendingVotes);
 		this.proposerElection = Objects.requireNonNull(proposerElection);
 		this.selfKey = Objects.requireNonNull(selfKey);
+		this.signer = Objects.requireNonNull(signer);
 		this.validatorSet = Objects.requireNonNull(validatorSet);
 		this.counters = Objects.requireNonNull(counters);
 	}
@@ -115,7 +118,7 @@ public final class BFTEventReducer implements BFTEventProcessor {
 	// Hotstuff's Event-Driven OnNextSyncView
 	private void proceedToView(View nextView) {
 		// TODO make signing more robust by including author in signed hash
-		ECDSASignature signature = this.selfKey.sign(Hash.hash256(Longs.toByteArray(nextView.number())));
+		ECDSASignature signature = this.signer.sign(this.selfKey, Hash.hash256(Longs.toByteArray(nextView.number())));
 		NewView newView = new NewView(
 			selfKey.getPublicKey(),
 			nextView,
@@ -173,7 +176,7 @@ public final class BFTEventReducer implements BFTEventProcessor {
 			log.trace("{}: VOTE: Formed QC: {}", this::getShortName, () -> qc);
 			if (vertexStore.syncToQC(qc, vertexStore.getHighestCommittedQC(), vote.getAuthor())) {
 				if (!synchedLog) {
-					log.info("{}: VOTE: QC Synced: {}", this::getShortName, () -> qc);
+					log.debug("{}: VOTE: QC Synced: {}", this::getShortName, () -> qc);
 					synchedLog = true;
 				}
 				processQC(qc).ifPresent(commitMetaData -> {
@@ -184,7 +187,7 @@ public final class BFTEventReducer implements BFTEventProcessor {
 				});
 			} else {
 				if (synchedLog) {
-					log.info("{}: VOTE: QC Not synced: {}", this::getShortName, () -> qc);
+					log.debug("{}: VOTE: QC Not synced: {}", this::getShortName, () -> qc);
 					synchedLog = false;
 				}
 				unsyncedQCs.put(qc.getProposed().getId(), qc);

--- a/radixdlt/src/main/java/com/radixdlt/consensus/EpochManager.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/EpochManager.java
@@ -35,6 +35,7 @@ import com.radixdlt.counters.SystemCounters;
 import com.radixdlt.counters.SystemCounters.CounterType;
 import com.radixdlt.crypto.ECPublicKey;
 import com.radixdlt.crypto.Hash;
+import com.radixdlt.identifiers.EUID;
 import com.radixdlt.middleware2.CommittedAtom;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -326,6 +327,10 @@ public final class EpochManager {
 	}
 
 	private String nodeName(ECPublicKey key) {
-		return key.euid().toString().substring(0, 6);
+		if (key == null) {
+			return "null";
+		}
+		EUID euid = key.euid();
+		return euid == null ? "null" : euid.toString().substring(0, 6);
 	}
 }

--- a/radixdlt/src/main/java/com/radixdlt/consensus/EpochManager.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/EpochManager.java
@@ -39,6 +39,7 @@ import com.radixdlt.middleware2.CommittedAtom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -131,11 +132,11 @@ public final class EpochManager {
 		final VertexStoreEventProcessor vertexStoreEventProcessor;
 
 		if (!validatorSet.containsKey(selfPublicKey)) {
-			log.info("{}: EPOCH_CHANGE: {} Not part of validator set", this.loggerPrefix, epochChange);
+			logEpochChange(epochChange, "excluded from");
 			bftEventProcessor =  EmptyBFTEventProcessor.INSTANCE;
 			vertexStoreEventProcessor = EmptyVertexStoreEventProcessor.INSTANCE;
 		} else {
-			log.info("{}: EPOCH_CHANGE: {} Part of validator set", this.loggerPrefix, epochChange);
+			logEpochChange(epochChange, "included in");
 			ProposerElection proposerElection = proposerElectionFactory.create(validatorSet);
 			TimeoutSender sender = (view, ms) -> localTimeoutSender.scheduleTimeout(new LocalTimeout(nextEpoch, view), ms);
 			Pacemaker pacemaker = pacemakerFactory.create(sender);
@@ -183,6 +184,33 @@ public final class EpochManager {
 		queuedEvents.remove(nextEpoch);
 	}
 
+	private void logEpochChange(EpochChange epochChange, String message) {
+		if (log.isInfoEnabled()) {
+			// Reduce complexity of epoch change log message, and make it easier to correlate with
+			// other logs.  Size reduced from circa 6Kib to approx 1Kib over ValidatorSet.toString().
+			StringBuilder epochMessage = new StringBuilder(this.loggerPrefix);
+			epochMessage.append(": EPOCH_CHANGE: ").append(nodeName(this.selfPublicKey));
+			epochMessage.append(' ').append(message);
+			epochMessage.append(" new epoch ").append(epochChange.getAncestor().getEpoch() + 1);
+			epochMessage.append(" with validators: ");
+			Iterator<Validator> i = epochChange.getValidatorSet().getValidators().iterator();
+			if (i.hasNext()) {
+				appendValidator(epochMessage, i.next());
+				while (i.hasNext()) {
+					epochMessage.append(',');
+					appendValidator(epochMessage, i.next());
+				}
+			} else {
+				epochMessage.append("[NONE]");
+			}
+			log.info("{}", epochMessage);
+		}
+	}
+
+	private void appendValidator(StringBuilder msg, Validator v) {
+		msg.append(nodeName(v.nodeKey())).append(':').append(v.getPower());
+	}
+
 	private void processEndOfEpoch(VertexMetadata vertexMetadata) {
 		log.info("{}: END_OF_EPOCH: {}", this.loggerPrefix, vertexMetadata);
 		if (this.lastConstructed == null || this.lastConstructed.getEpoch() < vertexMetadata.getEpoch()) {
@@ -225,7 +253,7 @@ public final class EpochManager {
 	private void processConsensusEventInternal(ConsensusEvent consensusEvent) {
 		if (this.currentValidatorSet != null && !this.currentValidatorSet.containsKey(consensusEvent.getAuthor())) {
 			log.warn("{}: CONSENSUS_EVENT: Received event from author={} not in validator set={}",
-				this.loggerPrefix, consensusEvent.getAuthor(), this.currentValidatorSet
+				this.loggerPrefix, nodeName(consensusEvent.getAuthor()), this.currentValidatorSet
 			);
 			return;
 		}
@@ -295,5 +323,9 @@ public final class EpochManager {
 
 	public void processCommittedStateSync(CommittedStateSync committedStateSync) {
 		vertexStoreEventProcessor.processCommittedStateSync(committedStateSync);
+	}
+
+	private String nodeName(ECPublicKey key) {
+		return key.euid().toString().substring(0, 6);
 	}
 }

--- a/radixdlt/src/main/java/com/radixdlt/consensus/HashSigner.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/HashSigner.java
@@ -1,0 +1,48 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package com.radixdlt.consensus;
+
+import com.radixdlt.crypto.ECDSASignature;
+import com.radixdlt.crypto.ECKeyPair;
+import com.radixdlt.crypto.Hash;
+
+/**
+ * Signs a hash.
+ */
+@FunctionalInterface
+public interface HashSigner {
+	/**
+	 * Sign the specified hash with the specified key.
+	 *
+	 * @param hash The hash to sign
+	 * @param key The key to sign with
+	 * @return The {@link ECDSASignature}
+	 */
+	ECDSASignature sign(ECKeyPair key, byte[] hash);
+
+	/**
+	 * Sign the specified hash with the specified key.
+	 *
+	 * @param hash The hash to sign
+	 * @param key The key to sign with
+	 * @return The {@link ECDSASignature}
+	 */
+	default ECDSASignature sign(ECKeyPair key, Hash hash) {
+		return sign(key, hash.toByteArray());
+	}
+}

--- a/radixdlt/src/main/java/com/radixdlt/consensus/HashVerifier.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/HashVerifier.java
@@ -1,0 +1,39 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package com.radixdlt.consensus;
+
+import com.radixdlt.crypto.ECDSASignature;
+import com.radixdlt.crypto.ECPublicKey;
+import com.radixdlt.crypto.Hash;
+
+/**
+ * Verifies signatures against hashes.
+ */
+@FunctionalInterface
+public interface HashVerifier {
+	/**
+	 * Verify the specified signature against the specified hash with
+	 * the specified public key.
+	 *
+	 * @param pubKey The public key to verify with
+	 * @param hash The the hash to verify
+	 * @param sig The signature to verify
+	 * @return {@code true} if the signature matches, {@code false} otherwise
+	 */
+	boolean verify(ECPublicKey pubKey, Hash hash, ECDSASignature sig);
+}

--- a/radixdlt/src/main/java/com/radixdlt/consensus/PendingVotes.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/PendingVotes.java
@@ -77,9 +77,11 @@ public final class PendingVotes {
 	private final Map<Hash, ValidationState> voteState = Maps.newHashMap();
 	private final Map<ECPublicKey, PreviousVote> previousVotes = Maps.newHashMap();
 	private final Hasher hasher;
+	private final HashVerifier verifier;
 
-	public PendingVotes(Hasher hasher) {
+	public PendingVotes(Hasher hasher, HashVerifier verifier) {
 		this.hasher = Objects.requireNonNull(hasher);
+		this.verifier = Objects.requireNonNull(verifier);
 	}
 
 	/**
@@ -97,7 +99,7 @@ public final class PendingVotes {
 		final ECDSASignature signature = vote.getSignature().orElseThrow(() -> new IllegalArgumentException("vote is missing signature"));
 		// Only process for valid validators and signatures
 		if (validatorSet.containsKey(voteAuthor)) {
-			if (voteAuthor.verify(voteHash, signature)) {
+			if (this.verifier.verify(voteAuthor, voteHash, signature)) {
 				final View voteView = voteData.getProposed().getView();
 				if (replacePreviousVote(voteAuthor, voteView, voteHash)) {
 					// If there is no equivocation or duplication, we process the vote.

--- a/radixdlt/src/main/java/com/radixdlt/consensus/bft/VertexStore.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/bft/VertexStore.java
@@ -434,6 +434,10 @@ public final class VertexStore implements VertexStoreEventProcessor {
 			throw new MissingParentException(vertex.getParentId());
 		}
 
+		if (!vertex.hasDirectParent()) {
+			counters.increment(CounterType.CONSENSUS_INDIRECT_PARENT);
+		}
+
 		final Vertex vertexToUse;
 		if (vertex.getParentMetadata().isEndOfEpoch()) {
 			// TODO: Check if current proposal is actually an empty client atom

--- a/radixdlt/src/main/java/com/radixdlt/consensus/bft/VertexStore.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/bft/VertexStore.java
@@ -218,14 +218,14 @@ public final class VertexStore implements VertexStoreEventProcessor {
 	public void processGetVerticesRequest(GetVerticesRequest request) {
 		// TODO: Handle nodes trying to DDOS this endpoint
 
-		log.info("SYNC_VERTICES: Received GetVerticesRequest {}", request);
+		log.trace("SYNC_VERTICES: Received GetVerticesRequest {}", request);
 		ImmutableList<Vertex> fetched = this.getVertices(request.getVertexId(), request.getCount());
 		if (fetched.isEmpty()) {
 			this.syncVerticesRPCSender.sendGetVerticesErrorResponse(request, this.getHighestQC(), this.getHighestCommittedQC());
 			return;
 		}
 
-		log.info("SYNC_VERTICES: Sending Response {}", fetched);
+		log.trace("SYNC_VERTICES: Sending Response {}", fetched);
 		this.syncVerticesRPCSender.sendGetVerticesResponse(request, fetched);
 	}
 
@@ -318,7 +318,7 @@ public final class VertexStore implements VertexStoreEventProcessor {
 	public void processGetVerticesResponse(GetVerticesResponse response) {
 		// TODO: check response
 
-		log.info("SYNC_VERTICES: Received GetVerticesResponse {}", response);
+		log.trace("SYNC_VERTICES: Received GetVerticesResponse {}", response);
 
 		final Hash syncTo = (Hash) response.getOpaque();
 		SyncState syncState = syncing.get(syncTo);
@@ -340,20 +340,20 @@ public final class VertexStore implements VertexStoreEventProcessor {
 
 	private void doQCSync(SyncState syncState) {
 		syncState.setSyncStage(SyncStage.GET_QC_VERTICES);
-		log.info("SYNC_VERTICES: QC: Sending initial GetVerticesRequest for sync={}", syncState);
+		log.debug("SYNC_VERTICES: QC: Sending initial GetVerticesRequest for sync={}", syncState);
 		syncVerticesRPCSender.sendGetVerticesRequest(syncState.qc.getProposed().getId(), syncState.author, 1, syncState.localSyncId);
 	}
 
 	private void doCommittedSync(SyncState syncState) {
 		final Hash committedQCId = syncState.getCommittedQC().getProposed().getId();
 		syncState.setSyncStage(SyncStage.GET_COMMITTED_VERTICES);
-		log.info("SYNC_VERTICES: Committed: Sending initial GetVerticesRequest for sync={}", syncState);
+		log.debug("SYNC_VERTICES: Committed: Sending initial GetVerticesRequest for sync={}", syncState);
 		// Retrieve the 3 vertices preceding the committedQC so we can create a valid committed root
 		syncVerticesRPCSender.sendGetVerticesRequest(committedQCId, syncState.author, 3, syncState.localSyncId);
 	}
 
 	public void processLocalSync(Hash vertexId) {
-		log.info("LOCAL_SYNC: Processed {}", vertexId);
+		log.debug("LOCAL_SYNC: Processed {}", vertexId);
 		syncing.remove(vertexId);
 	}
 
@@ -377,7 +377,7 @@ public final class VertexStore implements VertexStoreEventProcessor {
 			return true;
 		}
 
-		log.info("SYNC_TO_QC: Need sync: {} {}", qc, committedQC);
+		log.debug("SYNC_TO_QC: Need sync: {} {}", qc, committedQC);
 
 		final Hash vertexId = qc.getProposed().getId();
 		if (syncing.containsKey(vertexId)) {

--- a/radixdlt/src/main/java/com/radixdlt/consensus/bft/VertexStore.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/bft/VertexStore.java
@@ -194,10 +194,6 @@ public final class VertexStore implements VertexStoreEventProcessor {
 			this.syncStage = syncStage;
 		}
 
-		QuorumCertificate getQC() {
-			return qc;
-		}
-
 		QuorumCertificate getCommittedQC() {
 			return committedQC;
 		}

--- a/radixdlt/src/main/java/com/radixdlt/consensus/epoch/GetEpochRequest.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/epoch/GetEpochRequest.java
@@ -40,6 +40,7 @@ public final class GetEpochRequest {
 		return sender;
 	}
 
+	@Override
 	public String toString() {
 		return String.format("%s{author=%s epoch=%s}", this.getClass().getSimpleName(), this.sender, this.epoch);
 	}

--- a/radixdlt/src/main/java/com/radixdlt/consensus/liveness/LocalTimeoutSender.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/liveness/LocalTimeoutSender.java
@@ -25,5 +25,5 @@ import com.radixdlt.consensus.LocalTimeout;
  * @see FixedTimeoutPacemaker.TimeoutSender
  */
 public interface LocalTimeoutSender {
-	public void scheduleTimeout(LocalTimeout localTimeout, long timeoutMilliseconds);
+	void scheduleTimeout(LocalTimeout localTimeout, long timeoutMilliseconds);
 }

--- a/radixdlt/src/main/java/com/radixdlt/consensus/liveness/LocalTimeoutSender.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/liveness/LocalTimeoutSender.java
@@ -1,0 +1,29 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package com.radixdlt.consensus.liveness;
+
+import com.radixdlt.consensus.LocalTimeout;
+
+/**
+ * Sender for local timeouts.
+ *
+ * @see FixedTimeoutPacemaker.TimeoutSender
+ */
+public interface LocalTimeoutSender {
+	public void scheduleTimeout(LocalTimeout localTimeout, long timeoutMilliseconds);
+}

--- a/radixdlt/src/main/java/com/radixdlt/consensus/liveness/ScheduledLocalTimeoutSender.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/liveness/ScheduledLocalTimeoutSender.java
@@ -30,7 +30,7 @@ import org.apache.logging.log4j.Logger;
 /**
  * Schedules timeouts and exposes the events as an rx stream
  */
-public final class ScheduledTimeoutSender implements PacemakerRx {
+public final class ScheduledLocalTimeoutSender implements PacemakerRx, LocalTimeoutSender {
 	private static final Logger log = LogManager.getLogger();
 	private static final long LOGGING_INTERVAL = TimeUnit.SECONDS.toMillis(1);
 	private final ScheduledExecutorService executorService;
@@ -38,7 +38,7 @@ public final class ScheduledTimeoutSender implements PacemakerRx {
 	private final Observable<LocalTimeout> timeoutsObservable;
 	private long nextLogging = 0;
 
-	public ScheduledTimeoutSender(ScheduledExecutorService executorService) {
+	public ScheduledLocalTimeoutSender(ScheduledExecutorService executorService) {
 		this.executorService = Objects.requireNonNull(executorService);
 		// BehaviorSubject so that nextLocalTimeout will complete if timeout already occurred
 		this.timeouts = BehaviorSubject.<LocalTimeout>create().toSerialized();
@@ -47,6 +47,7 @@ public final class ScheduledTimeoutSender implements PacemakerRx {
 			.refCount();
 	}
 
+	@Override
 	public void scheduleTimeout(LocalTimeout localTimeout, long timeoutMilliseconds) {
 		long crtTime = System.currentTimeMillis();
 		if (crtTime >= nextLogging) {
@@ -62,5 +63,4 @@ public final class ScheduledTimeoutSender implements PacemakerRx {
 	public Observable<LocalTimeout> localTimeouts() {
 		return this.timeoutsObservable;
 	}
-
 }

--- a/radixdlt/src/main/java/com/radixdlt/consensus/safety/SafetyRules.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/safety/SafetyRules.java
@@ -18,6 +18,7 @@
 package com.radixdlt.consensus.safety;
 
 import com.radixdlt.consensus.Hasher;
+import com.radixdlt.consensus.HashSigner;
 import com.radixdlt.consensus.Proposal;
 import com.radixdlt.consensus.QuorumCertificate;
 import com.radixdlt.consensus.Vertex;
@@ -39,17 +40,20 @@ import java.util.Optional;
 public final class SafetyRules {
 	private final ECKeyPair selfKey; // TODO remove signing/address to separate identity management
 	private final Hasher hasher;
+	private final HashSigner signer;
 
 	private SafetyState state;
 
 	public SafetyRules(
 		ECKeyPair selfKey,
 		SafetyState initialState,
-		Hasher hasher
+		Hasher hasher,
+		HashSigner signer
 	) {
 		this.selfKey = Objects.requireNonNull(selfKey);
 		this.state = Objects.requireNonNull(initialState);
 		this.hasher = Objects.requireNonNull(hasher);
+		this.signer = Objects.requireNonNull(signer);
 	}
 
 	/**
@@ -97,7 +101,7 @@ public final class SafetyRules {
 	 */
 	public Proposal signProposal(Vertex proposedVertex, QuorumCertificate highestCommittedQC) {
 		final Hash vertexHash = this.hasher.hash(proposedVertex);
-		ECDSASignature signature = this.selfKey.sign(vertexHash);
+		ECDSASignature signature = this.signer.sign(this.selfKey, vertexHash);
 		return new Proposal(proposedVertex, highestCommittedQC, this.selfKey.getPublicKey(), signature);
 	}
 
@@ -150,7 +154,7 @@ public final class SafetyRules {
 		this.state = safetyStateBuilder.build();
 
 		// TODO make signing more robust by including author in signed hash
-		ECDSASignature signature = this.selfKey.sign(voteHash);
+		ECDSASignature signature = this.signer.sign(this.selfKey, voteHash);
 		return new Vote(selfKey.getPublicKey(), voteData, signature);
 	}
 }

--- a/radixdlt/src/main/java/com/radixdlt/properties/PersistedProperties.java
+++ b/radixdlt/src/main/java/com/radixdlt/properties/PersistedProperties.java
@@ -60,8 +60,10 @@ public class PersistedProperties {
 			// No need to immediately save, we just loaded them
 			log.info("Loaded properties from {}", file);
 			loaded = true;
+		} catch (FileNotFoundException ex) {
+			log.info("Can not open properties file {}, using default", file);
 		} catch (IOException ex) {
-			log.error("Can not open properties file {}" + file + ", using default", ex);
+			log.error(String.format("Can not open properties file %s, using default", file), ex);
 		}
 
 		// Try in resource if not loaded
@@ -75,9 +77,12 @@ public class PersistedProperties {
 				// Save to file, so they can be edited later
 				save(filename);
 				log.info("Saved default properties in {}", file);
+			} catch (FileNotFoundException ex) {
+				log.error("Can not find properties file {}", file);
+				throw new ParseException("Can not find properties file " + file);
 			} catch (IOException ex) {
-				log.fatal("Can not load default properties for " + file, ex);
-				throw new ParseException("Can not load properties file, fatal!");
+				log.error(String.format("Can not load default properties for %s", file), ex);
+				throw new ParseException(String.format("Can not load properties file '%s' (%s)", file, ex.getMessage()));
 			}
 		}
 	}

--- a/radixdlt/src/main/java/org/radix/api/http/RadixHttpServer.java
+++ b/radixdlt/src/main/java/org/radix/api/http/RadixHttpServer.java
@@ -21,7 +21,6 @@ import com.radixdlt.consensus.ConsensusRunner;
 import com.google.common.collect.EvictingQueue;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
-import com.radixdlt.consensus.QuorumCertificate;
 import com.radixdlt.consensus.Vertex;
 import com.radixdlt.consensus.VertexStoreEventsRx;
 import com.radixdlt.mempool.SubmissionControl;

--- a/radixdlt/src/test/java/com/radixdlt/consensus/AddressBookValidatorSetProviderTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/AddressBookValidatorSetProviderTest.java
@@ -41,7 +41,7 @@ public class AddressBookValidatorSetProviderTest {
 		ECPublicKey peerKey = mock(ECPublicKey.class);
 		when(system.getKey()).thenReturn(peerKey);
 		when(peer.getSystem()).thenReturn(system);
-		when(addressBook.peers()).thenReturn(Stream.of(peer), Stream.of(peer));
+		when(addressBook.peers()).thenAnswer(inv -> Stream.of(peer));
 		ValidatorSet validatorSet = validatorSetProvider.getValidatorSet(0);
 		assertThat(validatorSet.getValidators()).hasSize(1);
 		assertThat(validatorSet.getValidators()).allMatch(v -> v.nodeKey().equals(self));

--- a/radixdlt/src/test/java/com/radixdlt/consensus/BFTEventReducerTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/BFTEventReducerTest.java
@@ -92,6 +92,7 @@ public class BFTEventReducerTest {
 			pendingVotes,
 			proposerElection,
 			SELF_KEY,
+			ECKeyPair::sign,
 			validatorSet,
 			counters
 		);

--- a/radixdlt/src/test/java/com/radixdlt/consensus/EpochManagerTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/EpochManagerTest.java
@@ -80,7 +80,9 @@ public class EpochManagerTest {
 		this.bftFactory = mock(BFTFactory.class);
 
 		this.systemCounters = new SystemCountersImpl();
-		this.syncedStateComputer = mock(SyncedStateComputer.class);
+		@SuppressWarnings("unchecked")
+		SyncedStateComputer<CommittedAtom> ssc = mock(SyncedStateComputer.class);
+		this.syncedStateComputer = ssc;
 
 		this.proposerElection = mock(ProposerElection.class);
 

--- a/radixdlt/src/test/java/com/radixdlt/consensus/EpochManagerTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/EpochManagerTest.java
@@ -105,6 +105,7 @@ public class EpochManagerTest {
 		EpochChange epochChange = mock(EpochChange.class);
 		ValidatorSet validatorSet = mock(ValidatorSet.class);
 		when(validatorSet.containsKey(eq(publicKey))).thenReturn(false);
+		when(validatorSet.getValidators()).thenReturn(ImmutableSet.of());
 		when(epochChange.getValidatorSet()).thenReturn(validatorSet);
 		VertexMetadata vertexMetadata = mock(VertexMetadata.class);
 		when(epochChange.getAncestor()).thenReturn(vertexMetadata);
@@ -130,6 +131,7 @@ public class EpochManagerTest {
 	public void when_receive_next_epoch_then_epoch_request__then_should_return_current_ancestor() {
 		VertexMetadata ancestor = VertexMetadata.ofGenesisAncestor();
 		ValidatorSet validatorSet = mock(ValidatorSet.class);
+		when(validatorSet.getValidators()).thenReturn(ImmutableSet.of());
 		epochManager.processEpochChange(new EpochChange(ancestor, validatorSet));
 		ECPublicKey sender = mock(ECPublicKey.class);
 		epochManager.processGetEpochRequest(new GetEpochRequest(sender, ancestor.getEpoch() + 1));
@@ -348,6 +350,7 @@ public class EpochManagerTest {
 		when(validator.nodeKey()).thenReturn(mock(ECPublicKey.class));
 		ValidatorSet validatorSet = mock(ValidatorSet.class);
 		when(validatorSet.containsKey(any())).thenReturn(false);
+		when(validatorSet.getValidators()).thenReturn(ImmutableSet.of());
 		epochManager.processEpochChange(new EpochChange(ancestor, validatorSet));
 
 		assertThat(systemCounters.get(CounterType.EPOCH_MANAGER_QUEUED_CONSENSUS_EVENTS)).isEqualTo(0);

--- a/radixdlt/src/test/java/com/radixdlt/consensus/EpochManagerTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/EpochManagerTest.java
@@ -38,9 +38,9 @@ import com.radixdlt.consensus.bft.VertexStore.GetVerticesRequest;
 import com.radixdlt.consensus.bft.GetVerticesResponse;
 import com.radixdlt.consensus.epoch.GetEpochRequest;
 import com.radixdlt.consensus.epoch.GetEpochResponse;
+import com.radixdlt.consensus.liveness.LocalTimeoutSender;
 import com.radixdlt.consensus.liveness.Pacemaker;
 import com.radixdlt.consensus.liveness.ProposerElection;
-import com.radixdlt.consensus.liveness.ScheduledTimeoutSender;
 import com.radixdlt.consensus.validators.Validator;
 import com.radixdlt.consensus.validators.ValidatorSet;
 import com.radixdlt.counters.SystemCounters;
@@ -90,7 +90,7 @@ public class EpochManagerTest {
 			"name",
 			this.syncedStateComputer,
 			this.syncEpochsRPCSender,
-			mock(ScheduledTimeoutSender.class),
+			mock(LocalTimeoutSender.class),
 			timeoutSender -> this.pacemaker,
 			vertexStoreFactory,
 			proposers -> proposerElection,

--- a/radixdlt/src/test/java/com/radixdlt/consensus/PendingVotesTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/PendingVotesTest.java
@@ -50,7 +50,7 @@ public class PendingVotesTest {
 	public void setup() {
 		this.hasher = mock(Hasher.class);
 		when(hasher.hash(any())).thenReturn(Hash.random());
-		this.pendingVotes = new PendingVotes(hasher);
+		this.pendingVotes = new PendingVotes(hasher, ECPublicKey::verify);
 	}
 
 	@Test

--- a/radixdlt/src/test/java/com/radixdlt/consensus/bft/VertexStoreTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/bft/VertexStoreTest.java
@@ -20,6 +20,7 @@ package com.radixdlt.consensus.bft;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -120,7 +121,8 @@ public class VertexStoreTest {
 		VoteData voteData = new VoteData(nextVertexMetadata, genesisVertexMetadata, null);
 		QuorumCertificate badRootQC = new QuorumCertificate(voteData, new ECDSASignatures());
 		assertThatThrownBy(() -> {
-			new VertexStore(genesisVertex, badRootQC, syncedStateComputer, syncVerticesRPCSender, vertexStoreEventSender, counters);
+			VertexStore vs = new VertexStore(genesisVertex, badRootQC, syncedStateComputer, syncVerticesRPCSender, vertexStoreEventSender, counters);
+			assertNull(vs); // Fail here
 		}).isInstanceOf(IllegalStateException.class);
 	}
 

--- a/radixdlt/src/test/java/com/radixdlt/consensus/liveness/FixedTimeoutPacemakerTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/liveness/FixedTimeoutPacemakerTest.java
@@ -54,14 +54,17 @@ public class FixedTimeoutPacemakerTest {
 	public void setUp() {
 		this.timeout = 100;
 		this.timeoutSender = mock(FixedTimeoutPacemaker.TimeoutSender.class);
-		this.pacemaker = new FixedTimeoutPacemaker(timeout, this.timeoutSender);
+		this.pacemaker = new FixedTimeoutPacemaker(timeout, this.timeoutSender, ECPublicKey::verify);
 	}
 
 	@Test
 	public void when_creating_pacemaker_with_invalid_timeout__then_exception_is_thrown() {
-		assertThatThrownBy(() -> new FixedTimeoutPacemaker(0, mock(FixedTimeoutPacemaker.TimeoutSender.class)));
-		assertThatThrownBy(() -> new FixedTimeoutPacemaker(-1, mock(FixedTimeoutPacemaker.TimeoutSender.class)));
-		assertThatThrownBy(() -> new FixedTimeoutPacemaker(-100, mock(FixedTimeoutPacemaker.TimeoutSender.class)));
+		assertThatThrownBy(() -> new FixedTimeoutPacemaker(0, mock(FixedTimeoutPacemaker.TimeoutSender.class), ECPublicKey::verify))
+			.isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> new FixedTimeoutPacemaker(-1, mock(FixedTimeoutPacemaker.TimeoutSender.class), ECPublicKey::verify))
+			.isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> new FixedTimeoutPacemaker(-100, mock(FixedTimeoutPacemaker.TimeoutSender.class), ECPublicKey::verify))
+			.isInstanceOf(IllegalArgumentException.class);
 	}
 
 	@Test

--- a/radixdlt/src/test/java/com/radixdlt/consensus/liveness/FixedTimeoutPacemakerTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/liveness/FixedTimeoutPacemakerTest.java
@@ -118,8 +118,10 @@ public class FixedTimeoutPacemakerTest {
 		when(newViewWithoutSignature.getQC()).thenReturn(qc);
 		when(newViewWithoutSignature.getView()).thenReturn(View.of(2L));
 		when(newViewWithoutSignature.getSignature()).thenReturn(Optional.empty());
+		ValidatorSet validatorSet = mock(ValidatorSet.class);
+		when(validatorSet.containsKey(any())).thenReturn(true);
 
-		assertThatThrownBy(() -> pacemaker.processNewView(newViewWithoutSignature, mock(ValidatorSet.class)))
+		assertThatThrownBy(() -> pacemaker.processNewView(newViewWithoutSignature, validatorSet))
 			.isInstanceOf(IllegalArgumentException.class);
 	}
 

--- a/radixdlt/src/test/java/com/radixdlt/consensus/liveness/PendingNewViewsTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/liveness/PendingNewViewsTest.java
@@ -46,7 +46,7 @@ public class PendingNewViewsTest {
 
 	@Before
 	public void setup() {
-		this.pendingNewViews = new PendingNewViews();
+		this.pendingNewViews = new PendingNewViews(ECPublicKey::verify);
 	}
 
 	@Test

--- a/radixdlt/src/test/java/com/radixdlt/consensus/liveness/ScheduledTimeoutSenderTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/liveness/ScheduledTimeoutSenderTest.java
@@ -39,7 +39,7 @@ import org.junit.Test;
 
 public class ScheduledTimeoutSenderTest {
 
-	private ScheduledTimeoutSender scheduledTimeoutSender;
+	private ScheduledLocalTimeoutSender scheduledLocalTimeoutSender;
 	private ScheduledExecutorService executorService;
 	private ScheduledExecutorService executorServiceMock;
 
@@ -54,7 +54,7 @@ public class ScheduledTimeoutSenderTest {
 			return null;
 		}).when(this.executorServiceMock).schedule(any(Runnable.class), anyLong(), any());
 
-		this.scheduledTimeoutSender = new ScheduledTimeoutSender(this.executorServiceMock);
+		this.scheduledLocalTimeoutSender = new ScheduledLocalTimeoutSender(this.executorServiceMock);
 	}
 
 	@After
@@ -67,10 +67,10 @@ public class ScheduledTimeoutSenderTest {
 
 	@Test
 	public void when_subscribed_to_local_timeouts_and_schedule_timeout__then_a_timeout_event_with_view_is_emitted() {
-		TestObserver<LocalTimeout> testObserver = scheduledTimeoutSender.localTimeouts().test();
+		TestObserver<LocalTimeout> testObserver = scheduledLocalTimeoutSender.localTimeouts().test();
 		LocalTimeout localTimeout = mock(LocalTimeout.class);
 		long timeout = 10;
-		scheduledTimeoutSender.scheduleTimeout(localTimeout, timeout);
+		scheduledLocalTimeoutSender.scheduleTimeout(localTimeout, timeout);
 		testObserver.awaitCount(1);
 		testObserver.assertNotComplete();
 		testObserver.assertValues(localTimeout);
@@ -79,12 +79,12 @@ public class ScheduledTimeoutSenderTest {
 
 	@Test
 	public void when_subscribed_to_local_timeouts_and_schedule_timeout_twice__then_two_timeout_events_are_emitted() {
-		TestObserver<LocalTimeout> testObserver = scheduledTimeoutSender.localTimeouts().test();
+		TestObserver<LocalTimeout> testObserver = scheduledLocalTimeoutSender.localTimeouts().test();
 		LocalTimeout timeout1 = mock(LocalTimeout.class);
 		LocalTimeout timeout2 = mock(LocalTimeout.class);
 		long timeout = 10;
-		scheduledTimeoutSender.scheduleTimeout(timeout1, timeout);
-		scheduledTimeoutSender.scheduleTimeout(timeout2, timeout);
+		scheduledLocalTimeoutSender.scheduleTimeout(timeout1, timeout);
+		scheduledLocalTimeoutSender.scheduleTimeout(timeout2, timeout);
 		testObserver.awaitCount(2);
 		testObserver.assertNotComplete();
 		testObserver.assertValues(timeout1, timeout2);

--- a/radixdlt/src/test/java/com/radixdlt/consensus/safety/SafetyRulesTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/safety/SafetyRulesTest.java
@@ -50,7 +50,7 @@ public class SafetyRulesTest {
 	@Before
 	public void setup() {
 		this.safetyState = mock(SafetyState.class);
-		this.safetyRules = new SafetyRules(ECKeyPair.generateNew(), safetyState, new DefaultHasher());
+		this.safetyRules = new SafetyRules(ECKeyPair.generateNew(), safetyState, new DefaultHasher(), ECKeyPair::sign);
 	}
 
 	@Test

--- a/radixdlt/src/test/java/com/radixdlt/consensus/sync/SyncedRadixEngineTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/sync/SyncedRadixEngineTest.java
@@ -83,7 +83,7 @@ public class SyncedRadixEngineTest {
 		this.stateSyncNetwork = mock(StateSyncNetwork.class);
 		this.committedStateSyncSender = mock(CommittedStateSyncSender.class);
 		this.epochChangeSender = mock(EpochChangeSender.class);
-		this.validatorSetMapping = mock(Function.class);
+		this.validatorSetMapping = epoch -> null;
 		this.epochHighView = View.of(100);
 		this.syncedRadixEngine = new SyncedRadixEngine(
 			radixEngine,

--- a/radixdlt/src/test/java/com/radixdlt/consensus/sync/SyncedRadixEngineTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/consensus/sync/SyncedRadixEngineTest.java
@@ -83,7 +83,10 @@ public class SyncedRadixEngineTest {
 		this.stateSyncNetwork = mock(StateSyncNetwork.class);
 		this.committedStateSyncSender = mock(CommittedStateSyncSender.class);
 		this.epochChangeSender = mock(EpochChangeSender.class);
-		this.validatorSetMapping = epoch -> null;
+		// No issues with type checking for mock
+		@SuppressWarnings("unchecked")
+		Function<Long, ValidatorSet> vsm = mock(Function.class);
+		this.validatorSetMapping = vsm;
 		this.epochHighView = View.of(100);
 		this.syncedRadixEngine = new SyncedRadixEngine(
 			radixEngine,

--- a/radixdlt/src/test/java/com/radixdlt/middleware2/store/CommittedAtomsStoreTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/middleware2/store/CommittedAtomsStoreTest.java
@@ -54,7 +54,7 @@ public class CommittedAtomsStoreTest {
 
 	@Before
 	public void setUp() {
-		this.store = mock(LedgerEntryStore.class, withSettings().verboseLogging());
+		this.store = mock(LedgerEntryStore.class);
 		this.atomToBinaryConverter = mock(AtomToBinaryConverter.class);
 		this.atomIndexer = mock(AtomIndexer.class);
 		this.counters = mock(SystemCounters.class);


### PR DESCRIPTION
Implementation of test where all proposals in a view are dropped.

Implemented timeouts, as well as some performance improvements via handling of messages, and ability to turn off hashing/signing and sig verification when it is not required.

Re-enabled some disabled tests in the anticipation that the performance improvements will allow them to work on Travis now.