### PR TITLE
Load ValidatorConstraintScrypt first to prevent dependency issue

### DIFF
--- a/radixdlt/build.gradle
+++ b/radixdlt/build.gradle
@@ -94,7 +94,7 @@ jacocoTestReport {
 }
 
 dependencies {
-    compile 'com.github.radixdlt:radix-engine-library:feature~rpnv1-499-remove-planck-SNAPSHOT'
+    compile 'com.github.radixdlt:radix-engine-library:feature~rpnv1-438-whitelist-SNAPSHOT'
 
     compile 'io.reactivex.rxjava3:rxjava:3.0.0'
     compile 'com.sleepycat:je:18.3.12'

--- a/radixdlt/src/main/java/com/radixdlt/SyncerModule.java
+++ b/radixdlt/src/main/java/com/radixdlt/SyncerModule.java
@@ -228,10 +228,10 @@ public class SyncerModule extends AbstractModule {
 			}
 			return Result.success();
 		});
+		os.load(new ValidatorConstraintScrypt()); // load before TokensConstraintScrypt due to dependency
 		os.load(new TokensConstraintScrypt());
 		os.load(new UniqueParticleConstraintScrypt());
 		os.load(new MessageParticleConstraintScrypt());
-		os.load(new ValidatorConstraintScrypt());
 		return os;
 	}
 


### PR DESCRIPTION
TokensConstraintScrypt now depends on the RegisteredValidatorParticle defined in the ValidatorConstraintScrypt, so the latter has to be loaded first