### PR TITLE
Make timestamps in Peer thread safe

### DIFF
--- a/radixdlt/src/main/java/com/radixdlt/network/addressbook/Peer.java
+++ b/radixdlt/src/main/java/com/radixdlt/network/addressbook/Peer.java
@@ -17,6 +17,7 @@
 
 package com.radixdlt.network.addressbook;
 
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -51,24 +52,30 @@ public abstract class Peer extends BasicContainer {
 
 	@JsonProperty("ban_reason")
 	@DsonOutput(Output.PERSIST)
-	private String banReason;
+	private volatile String banReason;
 
-	private EnumMap<Timestamps, AtomicLong> timestamps;
+	// Note that this map is fully populated on construction, and the
+	// structure (keys and values) cannot be changed during the object's
+	// lifetime.  Note that the contents of the values are changes, but
+	// not the values themselves.
+	private final Map<Timestamps, AtomicLong> timestamps;
 
 	protected Peer() {
 		banReason = null;
-		this.timestamps = new EnumMap<>(Timestamps.class);
+		EnumMap<Timestamps, AtomicLong> newTimestamps = new EnumMap<>(Timestamps.class);
 		for (Timestamps t : Timestamps.values()) {
-			this.timestamps.put(t, new AtomicLong(DEFAULT_TIMESTAMP));
+			newTimestamps.put(t, new AtomicLong(DEFAULT_TIMESTAMP));
 		}
+		this.timestamps = Collections.unmodifiableMap(newTimestamps);
 	}
 
 	protected Peer(Peer toCopy) {
 		this.banReason = toCopy.banReason;
-		this.timestamps = new EnumMap<>(Timestamps.class);
+		EnumMap<Timestamps, AtomicLong> newTimestamps = new EnumMap<>(Timestamps.class);
 		for (Timestamps t : Timestamps.values()) {
-			this.timestamps.put(t, new AtomicLong(toCopy.getTimestamp(t)));
+			newTimestamps.put(t, new AtomicLong(toCopy.getTimestamp(t)));
 		}
+		this.timestamps = Collections.unmodifiableMap(newTimestamps);
 	}
 
 	/**

--- a/radixdlt/src/main/java/org/radix/network/messages/TestMessage.java
+++ b/radixdlt/src/main/java/org/radix/network/messages/TestMessage.java
@@ -47,6 +47,12 @@ public final class TestMessage extends Message {
 		junk = new byte[1000];
 	}
 
+	public TestMessage(int magic, long timestamp) {
+		super(magic, timestamp);
+		testnonce = new SecureRandom().nextLong();
+		junk = new byte[1000];
+	}
+
 	public TestMessage(final int size, int magic) {
 		super(magic);
 		testnonce = new SecureRandom().nextLong();

--- a/radixdlt/src/main/java/org/radix/time/Timestamps.java
+++ b/radixdlt/src/main/java/org/radix/time/Timestamps.java
@@ -17,13 +17,13 @@
 
 package org.radix.time;
 
-public final class Timestamps {
-	public static final String ACTIVE = "active";
-	public static final String BANNED = "banned";
-	public static final String DEFAULT = "default";
-	public static final String PROBED = "probed";
+public enum Timestamps {
+	ACTIVE,
+	BANNED,
+	PROBED;
 
-	private Timestamps() {
-		throw new IllegalStateException("Cannot instantiate");
+	@Override
+	public String toString() {
+		return super.toString().toLowerCase();
 	}
 }

--- a/radixdlt/src/test/java/com/radixdlt/network/messaging/MessageCentralImplTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/network/messaging/MessageCentralImplTest.java
@@ -36,7 +36,6 @@ import org.junit.Test;
 import org.radix.events.Events;
 import org.radix.network.messages.TestMessage;
 import org.radix.network.messaging.Message;
-import org.radix.time.Timestamps;
 import org.radix.universe.system.LocalSystem;
 import org.radix.universe.system.events.QueueFullEvent;
 import org.xerial.snappy.Snappy;
@@ -186,8 +185,7 @@ public class MessageCentralImplTest {
 
 	@Test
 	public void testInjectMessageDeliveredToListeners() throws InterruptedException {
-		Message msg = new TestMessage(1);
-		msg.setTimestamp(Timestamps.DEFAULT, System.currentTimeMillis());
+		Message msg = new TestMessage(1, System.currentTimeMillis());
 		Peer peer = mock(Peer.class);
 
 		int numberOfRequests = 6;


### PR DESCRIPTION
Fixes an issue in Peer where timestamps are not threadsafe.

Note: Needs to be merged to RC, not infrastructure/refactor-ledger, but targeting that branch for review.