### PR TITLE
Fix Genesis Child timestamp

### DIFF
--- a/radixdlt/src/integration/java/com/radixdlt/integration/distributed/simulation/SimulationTest.java
+++ b/radixdlt/src/integration/java/com/radixdlt/integration/distributed/simulation/SimulationTest.java
@@ -69,6 +69,7 @@ import com.radixdlt.integration.distributed.simulation.application.NodeSelector;
 import com.radixdlt.integration.distributed.simulation.application.RadixEngineValidatorRegistrator;
 import com.radixdlt.integration.distributed.simulation.application.RadixEngineValidatorRegistratorAndUnregistrator;
 import com.radixdlt.integration.distributed.simulation.application.RegisteredValidatorChecker;
+import com.radixdlt.integration.distributed.simulation.application.TimestampChecker;
 import com.radixdlt.integration.distributed.simulation.invariants.epochs.EpochViewInvariant;
 import com.radixdlt.integration.distributed.simulation.application.LocalMempoolPeriodicSubmittor;
 import com.radixdlt.integration.distributed.simulation.invariants.ledger.ConsensusToLedgerCommittedInvariant;
@@ -309,6 +310,12 @@ public class SimulationTest {
 
 		public Builder randomLatency(int minLatency, int maxLatency) {
 			this.latencyProvider.setBase(new RandomLatencyProvider(minLatency, maxLatency));
+			return this;
+		}
+
+		public Builder addTimestampChecker(String invariantName) {
+			TimestampChecker timestampChecker = new TimestampChecker();
+			this.checksBuilder.put(invariantName, nodes -> timestampChecker);
 			return this;
 		}
 

--- a/radixdlt/src/integration/java/com/radixdlt/integration/distributed/simulation/application/TimestampChecker.java
+++ b/radixdlt/src/integration/java/com/radixdlt/integration/distributed/simulation/application/TimestampChecker.java
@@ -1,0 +1,43 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package com.radixdlt.integration.distributed.simulation.application;
+
+import com.radixdlt.consensus.bft.View;
+import com.radixdlt.integration.distributed.simulation.TestInvariant;
+import com.radixdlt.integration.distributed.simulation.network.SimulationNodes.RunningNetwork;
+import com.radixdlt.utils.Pair;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Observable;
+
+public class TimestampChecker implements TestInvariant {
+	private boolean timestampOkay(long timestamp) {
+		long now = System.currentTimeMillis();
+		return timestamp <= now && timestamp > now - 15_000;
+	}
+
+	@Override
+	public Observable<TestInvariantError> check(RunningNetwork network) {
+		return network.ledgerUpdates()
+			.map(Pair::getSecond)
+			.filter(l -> !(l.getTail().getEpoch() == 1 && l.getTail().getView().equals(View.of(1))))
+			.flatMapMaybe(update -> timestampOkay(update.getTail().timestamp())
+				? Maybe.empty()
+				: Maybe.just(new TestInvariantError("bad timestamp: " + update.getTail()))
+			);
+	}
+}

--- a/radixdlt/src/integration/java/com/radixdlt/integration/distributed/simulation/tests/consensus_ledger_epochs/MovingWindowValidatorsTest.java
+++ b/radixdlt/src/integration/java/com/radixdlt/integration/distributed/simulation/tests/consensus_ledger_epochs/MovingWindowValidatorsTest.java
@@ -49,6 +49,7 @@ public class MovingWindowValidatorsTest {
 			.pacemakerTimeout(5000)
 			.checkConsensusLiveness("liveness", 5000, TimeUnit.MILLISECONDS)
 			.checkEpochsHighViewCorrect("epochHighView", View.of(100))
+			.addTimestampChecker("timestamps")
 			.build();
 		TestResults results = bftTest.run();
 		assertThat(results.getCheckResults()).allSatisfy((name, err) -> AssertionsForClassTypes.assertThat(err).isEmpty());
@@ -61,6 +62,7 @@ public class MovingWindowValidatorsTest {
 			.pacemakerTimeout(1000)
 			.checkConsensusLiveness("liveness", 1000, TimeUnit.MILLISECONDS)
 			.checkEpochsHighViewCorrect("epochHighView", View.of(100))
+			.addTimestampChecker("timestamps")
 			.build();
 		TestResults results = bftTest.run();
 		assertThat(results.getCheckResults()).allSatisfy((name, err) -> AssertionsForClassTypes.assertThat(err).isEmpty());
@@ -74,6 +76,7 @@ public class MovingWindowValidatorsTest {
 			.pacemakerTimeout(5000)
 			.checkConsensusLiveness("liveness", 5000, TimeUnit.MILLISECONDS) // High timeout to make Travis happy
 			.checkEpochsHighViewCorrect("epochHighView", View.of(100))
+			.addTimestampChecker("timestamps")
 			.build();
 
 		TestResults results = bftTest.run();

--- a/radixdlt/src/integration/java/com/radixdlt/integration/distributed/simulation/tests/consensus_ledger_epochs/OneNodeNeverSendEpochResponseTest.java
+++ b/radixdlt/src/integration/java/com/radixdlt/integration/distributed/simulation/tests/consensus_ledger_epochs/OneNodeNeverSendEpochResponseTest.java
@@ -49,7 +49,8 @@ public class OneNodeNeverSendEpochResponseTest {
 		.checkConsensusNoTimeouts("noTimeouts")
 		.checkConsensusAllProposalsHaveDirectParents("directParents")
 		.checkLedgerInOrder("ledgerInOrder")
-		.checkLedgerProcessesConsensusCommitted("consensusToLedger");
+		.checkLedgerProcessesConsensusCommitted("consensusToLedger")
+		.addTimestampChecker("timestamps");
 
 	private static Function<Long, IntStream> randomEpochToNodesMapper(Function<Long, Random> randomSupplier) {
 		return epoch -> {

--- a/radixdlt/src/integration/java/com/radixdlt/integration/distributed/simulation/tests/consensus_ledger_epochs/RandomValidatorsTest.java
+++ b/radixdlt/src/integration/java/com/radixdlt/integration/distributed/simulation/tests/consensus_ledger_epochs/RandomValidatorsTest.java
@@ -46,7 +46,8 @@ public class RandomValidatorsTest {
 		.checkConsensusNoTimeouts("noTimeouts")
 		.checkConsensusAllProposalsHaveDirectParents("directParents")
 		.checkLedgerInOrder("ledgerInOrder")
-		.checkLedgerProcessesConsensusCommitted("consensusToLedger");
+		.checkLedgerProcessesConsensusCommitted("consensusToLedger")
+		.addTimestampChecker("timestamps");
 
 	private static Function<Long, IntStream> randomEpochToNodesMapper(Function<Long, Random> randomSupplier) {
 		return epoch -> {

--- a/radixdlt/src/integration/java/com/radixdlt/integration/distributed/simulation/tests/consensus_ledger_epochs/StaticValidatorsTest.java
+++ b/radixdlt/src/integration/java/com/radixdlt/integration/distributed/simulation/tests/consensus_ledger_epochs/StaticValidatorsTest.java
@@ -54,6 +54,7 @@ public class StaticValidatorsTest {
 		SimulationTest bftTest = bftTestBuilder
 			.ledgerAndEpochs(View.of(100), e -> IntStream.range(0, 4))
 			.checkEpochsHighViewCorrect("epochHighView", View.of(99))
+			.addTimestampChecker("timestamps")
 			.build();
 
 		TestResults results = bftTest.run();
@@ -65,6 +66,7 @@ public class StaticValidatorsTest {
 		SimulationTest bftTest = bftTestBuilder
 			.ledgerAndEpochs(View.of(100), e -> IntStream.range(0, 4))
 			.checkEpochsHighViewCorrect("epochHighView", View.of(100))
+			.addTimestampChecker("timestamps")
 			.build();
 
 		TestResults results = bftTest.run();

--- a/radixdlt/src/main/java/com/radixdlt/ledger/StateComputerLedger.java
+++ b/radixdlt/src/main/java/com/radixdlt/ledger/StateComputerLedger.java
@@ -102,7 +102,16 @@ public final class StateComputerLedger implements Ledger, NextCommandGenerator {
 			accumulatorState = this.accumulator.accumulate(parent.getAccumulatorState(), vertex.getCommand());
 		}
 
-		final long timestamp = vertex.getQC().getTimestampedSignatures().weightedTimestamp();
+		final long timestamp;
+		// if vertex has genesis parent then QC is mocked so just use previous timestamp
+		// this does have the edge case of never increasing timestamps if configuration is
+		// one view per epoch but good enough for now
+		if (vertex.getQC().getProposed().getView().isGenesis()) {
+			timestamp = vertex.getQC().getProposed().getLedgerHeader().timestamp();
+		} else {
+			timestamp = vertex.getQC().getTimestampedSignatures().weightedTimestamp();
+		}
+
 		return LedgerHeader.create(
 			parent.getEpoch(),
 			vertex.getView(),

--- a/radixdlt/src/main/java/com/radixdlt/ledger/StateComputerLedger.java
+++ b/radixdlt/src/main/java/com/radixdlt/ledger/StateComputerLedger.java
@@ -106,8 +106,8 @@ public final class StateComputerLedger implements Ledger, NextCommandGenerator {
 		// if vertex has genesis parent then QC is mocked so just use previous timestamp
 		// this does have the edge case of never increasing timestamps if configuration is
 		// one view per epoch but good enough for now
-		if (vertex.getQC().getProposed().getView().isGenesis()) {
-			timestamp = vertex.getQC().getProposed().getLedgerHeader().timestamp();
+		if (vertex.getParentHeader().getView().isGenesis()) {
+			timestamp = vertex.getParentHeader().getLedgerHeader().timestamp();
 		} else {
 			timestamp = vertex.getQC().getTimestampedSignatures().weightedTimestamp();
 		}

--- a/radixdlt/src/test/java/com/radixdlt/ledger/StateComputerLedgerTest.java
+++ b/radixdlt/src/test/java/com/radixdlt/ledger/StateComputerLedgerTest.java
@@ -113,6 +113,7 @@ public class StateComputerLedgerTest {
 
 		BFTHeader parent = mock(BFTHeader.class);
 		when(parent.getLedgerHeader()).thenReturn(ledgerHeader);
+		when(parent.getView()).thenReturn(View.of(1));
 		when(vertex.getParentHeader()).thenReturn(parent);
 
 		LedgerHeader nextPrepared = stateComputerLedger.prepare(vertex);
@@ -136,6 +137,7 @@ public class StateComputerLedgerTest {
 
 		BFTHeader parent = mock(BFTHeader.class);
 		when(parent.getLedgerHeader()).thenReturn(ledgerHeader);
+		when(parent.getView()).thenReturn(View.of(1));
 		when(vertex.getParentHeader()).thenReturn(parent);
 
 		LedgerHeader nextPrepared = stateComputerLedger.prepare(vertex);
@@ -159,6 +161,7 @@ public class StateComputerLedgerTest {
 
 		BFTHeader parent = mock(BFTHeader.class);
 		when(parent.getLedgerHeader()).thenReturn(ledgerHeader);
+		when(parent.getView()).thenReturn(View.of(1));
 		when(vertex.getParentHeader()).thenReturn(parent);
 
 		when(stateComputer.prepare(eq(vertex))).thenReturn(true);
@@ -181,6 +184,7 @@ public class StateComputerLedgerTest {
 		when(accumulatorState.getStateVersion()).thenReturn(12345L);
 		when(accumulatorState.getAccumulatorHash()).thenReturn(mock(Hash.class));
 		when(parentHeader.getAccumulatorState()).thenReturn(accumulatorState);
+		when(parentHeader.getView()).thenReturn(View.of(1));
 		AccumulatorState nextAccumulateState = mock(AccumulatorState.class);
 		when(nextAccumulateState.getStateVersion()).thenReturn(12346L);
 		when(nextAccumulateState.getAccumulatorHash()).thenReturn(mock(Hash.class));
@@ -188,6 +192,7 @@ public class StateComputerLedgerTest {
 		when(accumulator.accumulate(eq(accumulatorState), eq(command))).thenReturn(nextAccumulateState);
 		BFTHeader parent = mock(BFTHeader.class);
 		when(parent.getLedgerHeader()).thenReturn(parentHeader);
+		when(parent.getView()).thenReturn(View.of(1));
 		when(vertex.getParentHeader()).thenReturn(parent);
 		when(vertex.getCommand()).thenReturn(command);
 


### PR DESCRIPTION
* Since Genesis QC is mocked it doesn't contain signed timestamps like other QCs do, this leads to the child of genesis having no timestamp.
* Fix this so that the genesis child will reuse the previous timestamp