### PR TITLE
Added iptables installation to dockerfile

### DIFF
--- a/docker/Dockerfile.core
+++ b/docker/Dockerfile.core
@@ -2,7 +2,7 @@ FROM ubuntu:20.04
 MAINTAINER radixdlt <devops@radixdlt.com>
 
 RUN apt-get -y update && \
-    apt-get -y --no-install-recommends install net-tools gettext-base curl tcpdump strace attr software-properties-common openjdk-11-jdk && \
+    apt-get -y --no-install-recommends install net-tools iptables gettext-base curl tcpdump strace attr software-properties-common openjdk-11-jdk && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/*
 


### PR DESCRIPTION
iptables can be used to simulate out of synchrony conditions in [these tests](https://radixdlt.atlassian.net/browse/RPNV1-727).