### PR TITLE
Task/rpnv1 262 release branch job

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -87,16 +87,24 @@ pipeline {
         stage('Downstream jobs') {
             parallel {
                 stage('deploy-release'){
-                    build job: 'Release-Branch/deploy-release'
+                    steps{
+                        build job: 'Release-Branch/deploy-release'
+                    }
                 }
                 stage('docker-continuous-tests'){
-                    build job: 'Release-Branch/docker-continuous-tests'
+                    steps {
+                        build job: 'Release-Branch/docker-continuous-tests'
+                    }
                 }
                 stage('regression-acceptance-tests'){
-                    build job: 'Release-Branch/regression-acceptance-tests'
+                    steps{
+                        build job: 'Release-Branch/regression-acceptance-tests'
+                    }
                 }
                 stage('deterministic-simulation-tests'){
-                    build job: 'Release-Branch/deterministic-simulation-tests'
+                    steps{
+                        build job: 'Release-Branch/deterministic-simulation-tests'
+                    }
                 }
             }
         }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -55,6 +55,7 @@ pipeline {
                                         echo "passed"
                                     else 
                                         echo "failed"
+                                    fi
                                 ''', returnStdout: true
                         ).trim()
                         echo env.check

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -17,7 +17,7 @@
  * language governing permissions and limitations under the License.
  */
 
-@Library(value = 'jenkins-lib@test-build-radix-core', changelog = false) _
+@Library(value = 'jenkins-lib@develop', changelog = false) _
 
 pipeline {
     tools {

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
                                     ''', returnStdout: true).trim()
                         branch_commit = sh(script: '''
                                         git show-ref $(git rev-parse --abbrev-ref HEAD | sed 's/heads\\///g') | grep 'refs/heads' | cut -d " " -f1
-                                        ''', returnStdout: true).trim
+                                        ''', returnStdout: true).trim()
 
                         echo "Branch commit = ${branch_commit}"
                         echo "Tag commit = ${tag_commit}"

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('jenkins-lib@RPNV1-262-Jenkinsfile-setup') _
+@Library('jenkins-lib@task/RPNV1-262-Jenkinsfile-setup') _
 
 pipeline {
     tools {
@@ -44,6 +44,7 @@ pipeline {
                               git describe --abbrev=0 --tags
                             ''',returnStdout: true
                             ).trim()
+                    echo tag
                     docker.manualPushToDockerHub("radixdlt-core",tag)
                 }
             }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
                sh 'printenv'
                 checkout([
                         $class: 'GitSCM',
-                        branches: ["${BRANCH}"],
+                        branches: [env.BRANCH_NAME],
                         doGenerateSubmoduleConfigurations: false,
                         extensions: [
                                 [$class: 'RelativeTargetDirectory', clean: true, relativeTargetDir: 'RadixCore'],

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -53,9 +53,9 @@ pipeline {
             }
         }
     }
-    post {
-//        always {
-////            sendNotifications currentBuild.result
-//        }
-    }
+//    post {
+////        always {
+//////            sendNotifications currentBuild.result
+////        }
+//    }
 }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -17,7 +17,7 @@
  * language governing permissions and limitations under the License.
  */
 
-@Library('jenkins-lib@RPNV1-262-Jenkinsfile-setup') _
+@Library('jenkins-lib@develop') _
 
 pipeline {
     tools {
@@ -33,20 +33,9 @@ pipeline {
         stage('Checkout RadixCore') {
            steps {
                sendNotifications "STARTED"
-               sh 'printenv'
-                checkout([
-                        $class: 'GitSCM',
-                        branches: [[name: env.BRANCH_NAME]],
-                        doGenerateSubmoduleConfigurations: false,
-                        extensions: [
-                                [$class: 'RelativeTargetDirectory', clean: true, relativeTargetDir: 'RadixCore'],
-                                [$class: 'LocalBranch', localBranch: '**']
-                        ],
-                        submoduleCfg: [],
-                        userRemoteConfigs: [
-                                [credentialsId: '6271ba56-812d-4c72-a89f-89454ba64f1b', url: 'https://github.com/radixdlt/radixdlt-core.git']
-                        ]
-                ])
+               script {
+                   checkoutHelpers.checkout("RadixCore")
+               }
             }
         }
 
@@ -56,11 +45,9 @@ pipeline {
                     script {
                         tag = sh(
                                 script: '''
-                              git describe --abbrev=0 --tags
-                            ''', returnStdout: true
+                                    git describe --abbrev=0 --tags
+                                ''', returnStdout: true
                         ).trim()
-                        echo tag
-
                         dockerHelpers.manualPushToDockerHub("radixdlt-core", tag)
                     }
                 }
@@ -71,6 +58,5 @@ pipeline {
         always {
             sendNotifications currentBuild.result
        }
-
     }
 }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -1,6 +1,5 @@
 #!/usr/bin/env groovy
 
-#!groovy
 @Library('jenkins-lib@RPNV1-262-Jenkinsfile-setup') _
 
 pipeline {
@@ -45,7 +44,7 @@ pipeline {
                               git describe --abbrev=0 --tags
                             ''',returnStdout: true
                             ).trim()
-//                    docker.manualPushToDockerHub("radixdlt-core",tag)
+                    docker.manualPushToDockerHub("radixdlt-core",tag)
                 }
             }
         }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
 
         stage('Checkout RadixCore') {
             steps {
-               sendNotifications "STARTED"
+                sendNotifications "STARTED"
                 script {
                     dir('RadixCore') {
                         deleteDir()
@@ -56,9 +56,9 @@ pipeline {
                         echo "Branch commit = ${branch_commit}"
                         echo "Tag commit = ${tag_commit}"
 
-                        if(tag_commit == branch_commit){
+                        if (tag_commit == branch_commit) {
                             env.check = "TAG_CREATED"
-                        }else{
+                        } else {
                             env.check = "TAG_NOT_FOUND"
                         }
                         echo "Tag and Branch check resulted in ${env.check}"
@@ -94,26 +94,9 @@ pipeline {
                     env.check == "TAG_NOT_FOUND"
                 }
             }
-            parallel {
-                stage('deploy-release') {
-                    steps {
-                        build job: 'Release-Branch/deploy-release'
-                    }
-                }
-                stage('docker-continuous-tests') {
-                    steps {
-                        build job: 'Release-Branch/docker-continuous-tests'
-                    }
-                }
-                stage('regression-acceptance-tests') {
-                    steps {
-                        build job: 'Release-Branch/regression-acceptance-tests'
-                    }
-                }
-                stage('deterministic-simulation-tests') {
-                    steps {
-                        build job: 'Release-Branch/deterministic-simulation-tests'
-                    }
+            stage('deploy-release') {
+                steps {
+                    build job: 'Release-Branch/run-all-tests'
                 }
             }
         }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
         jdk 'open-jdk-11'
     }
     options {
-        timeout(time: 20, unit: 'MINUTES')
+        timeout(time: 2, unit: 'HOURS')
     }
     agent {
         label 'master'
@@ -46,19 +46,21 @@ pipeline {
             steps {
                 script {
                     dir('RadixCore') {
-                        env.check = sh(
-                                script: '''
-                                    tag_commit=`git show-ref $(git describe --abbrev=0 --tags) | cut -d" " -f1`
-                                    branch_commit=`git show-ref refs/remotes/origin/task/RPNV1-262-release-branch-job | cut -d" " -f1`
-                                    if [ $tag_commit == $branch_commit ] 
-                                    then 
-                                        echo "TAG_CREATED"
-                                    else 
-                                        echo "TAG_NOT_FOUND"
-                                    fi
-                                ''', returnStdout: true
-                        ).trim()
-                        echo env.check
+                        tag_commit = sh('''
+                                      git show-ref $(git describe --abbrev=0 --tags) | grep 'refs/tags/' | cut -d" " -f1
+                                    ''', returnStdout: true).trim()
+                        branch_commit = sh('''
+                                        git show-ref $(git rev-parse --abbrev-ref HEAD | sed 's/heads\\///g') | grep 'refs/heads' | cut -d " " -f1
+                                        ''', returnStdout: true)
+                        echo "Branch commit = ${branch_commit}"
+                        echo "Tag commit = ${tag_commit}"
+
+                        if(tag_commit == branch_commit){
+                            env.check = "TAG_CREATED"
+                        }else{
+                            env.check = "TAG_NOT_FOUND"
+                        }
+                        echo "Tag and Branch check resulted in ${env.check}"
 
                     }
                 }
@@ -92,23 +94,23 @@ pipeline {
                 }
             }
             parallel {
-                stage('deploy-release'){
-                    steps{
+                stage('deploy-release') {
+                    steps {
                         build job: 'Release-Branch/deploy-release'
                     }
                 }
-                stage('docker-continuous-tests'){
+                stage('docker-continuous-tests') {
                     steps {
                         build job: 'Release-Branch/docker-continuous-tests'
                     }
                 }
-                stage('regression-acceptance-tests'){
-                    steps{
+                stage('regression-acceptance-tests') {
+                    steps {
                         build job: 'Release-Branch/regression-acceptance-tests'
                     }
                 }
-                stage('deterministic-simulation-tests'){
-                    steps{
+                stage('deterministic-simulation-tests') {
+                    steps {
                         build job: 'Release-Branch/deterministic-simulation-tests'
                     }
                 }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -43,7 +43,7 @@ pipeline {
             }
         }
         stage('Check tag and branch have same commit') {
-            steps{
+            steps {
                 script {
                     dir('RadixCore') {
                         env.check = sh(
@@ -69,19 +69,20 @@ pipeline {
                 expression {
                     env.check == "passed"
                 }
-                steps {
-                    dir('RadixCore') {
-                        script {
-                            tag = sh(
-                                    script: '''
+            }
+            steps {
+                dir('RadixCore') {
+                    script {
+                        tag = sh(
+                                script: '''
                                     git describe --abbrev=0 --tags
                                 ''', returnStdout: true
-                            ).trim()
-                            dockerHelpers.manualPushToDockerHub("radixdlt-core", tag)
-                        }
+                        ).trim()
+                        dockerHelpers.manualPushToDockerHub("radixdlt-core", tag)
                     }
                 }
             }
+
         }
         stage('Downstream jobs') {
             steps {

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
                sh 'printenv'
                 checkout([
                         $class: 'GitSCM',
-                        branches: [env.BRANCH_NAME],
+                        branches: [[name: env.BRANCH_NAME]],
                         doGenerateSubmoduleConfigurations: false,
                         extensions: [
                                 [$class: 'RelativeTargetDirectory', clean: true, relativeTargetDir: 'RadixCore'],

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -53,6 +53,11 @@ pipeline {
                 }
             }
         }
+        stage('Deploy image on testnet'){
+            build job: 'Release-Branch/deploy-release'
+//            build job: 'Release-Branch/deterministic-simulation-tests'
+            build job: 'Release-Branch/regression-acceptance-tests'
+        }
     }
     post {
         always {

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -54,8 +54,8 @@ pipeline {
         }
     }
     post {
-        always {
-//            sendNotifications currentBuild.result
-        }
+//        always {
+////            sendNotifications currentBuild.result
+//        }
     }
 }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -30,20 +30,27 @@ pipeline {
         label 'master'
     }
     stages {
+        stage('Checkout RadixCore') {
+           steps {
+//               sendNotifications "STARTED"
+               script {
+                   checkoutHelpers.doCheckout("RadixCore")
+               }
+            }
+        }
 
         stage('Build and push core image') {
             steps {
-                //               sendNotifications "STARTED"
-                script {
-                    tag = sh(
-                            script: '''
-                                    git checkout ${BRANCH_NAME}
+                dir('RadixCore'){
+                    script {
+                        tag = sh(
+                                script: '''
                                     git describe --abbrev=0 --tags
                                 ''', returnStdout: true
-                    ).trim()
-                    dockerHelpers.manualPushToDockerHub("radixdlt-core", tag)
+                        ).trim()
+                        dockerHelpers.manualPushToDockerHub("radixdlt-core", tag)
+                    }
                 }
-
             }
         }
         stage('Downstream jobs') {
@@ -55,8 +62,8 @@ pipeline {
         }
     }
 //    post {
-////        always {
-//////            sendNotifications currentBuild.result
-////        }
+//        always {
+////            sendNotifications currentBuild.result
+//        }
 //    }
 }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -17,44 +17,36 @@
  * language governing permissions and limitations under the License.
  */
 
-@Library(value='jenkins-lib@test-build-radix-core', changelog=false) _
+@Library(value = 'jenkins-lib@test-build-radix-core', changelog = false) _
 
 pipeline {
     tools {
         jdk 'open-jdk-11'
     }
     options {
-      timeout(time: 20, unit: 'MINUTES')
+        timeout(time: 20, unit: 'MINUTES')
     }
     agent {
         label 'master'
     }
     stages {
-        stage('Checkout RadixCore') {
-           steps {
-               sendNotifications "STARTED"
-               script {
-                   checkoutHelpers.doCheckout("RadixCore")
-               }
-            }
-        }
 
         stage('Build and push core image') {
             steps {
-                dir('RadixCore'){
-                    script {
-                        tag = sh(
-                                script: '''
+                //               sendNotifications "STARTED"
+                script {
+                    tag = sh(
+                            script: '''
                                     git describe --abbrev=0 --tags
                                 ''', returnStdout: true
-                        ).trim()
-                        dockerHelpers.manualPushToDockerHub("radixdlt-core", tag)
-                    }
+                    ).trim()
+                    dockerHelpers.manualPushToDockerHub("radixdlt-core", tag)
                 }
+
             }
         }
-        stage('Downstream jobs'){
-            steps{
+        stage('Downstream jobs') {
+            steps {
                 build job: 'Release-Branch/deploy-release'
 //            build job: 'Release-Branch/deterministic-simulation-tests'
                 build job: 'Release-Branch/regression-acceptance-tests'
@@ -63,7 +55,7 @@ pipeline {
     }
     post {
         always {
-            sendNotifications currentBuild.result
-       }
+//            sendNotifications currentBuild.result
+        }
     }
 }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
                         doGenerateSubmoduleConfigurations: false,
                         extensions: [
                                 [$class: 'RelativeTargetDirectory', clean: true, relativeTargetDir: 'RadixCore'],
-                                [$class: 'LocalBranch', localBranch: '$BRANCH']
+                                [$class: 'LocalBranch', localBranch: '**']
                         ],
                         submoduleCfg: [],
                         userRemoteConfigs: [

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
            steps {
                sendNotifications "STARTED"
                script {
-                   checkoutHelpers.checkout("RadixCore")
+                   checkoutHelpers.doCheckout("RadixCore")
                }
             }
         }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -17,7 +17,7 @@
  * language governing permissions and limitations under the License.
  */
 
-@Library(value='jenkins-lib@develop', changelog=false) _
+@Library(value='jenkins-lib@test-build-radix-core', changelog=false) _
 
 pipeline {
     tools {

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -94,11 +94,10 @@ pipeline {
                     env.check == "TAG_NOT_FOUND"
                 }
             }
-            stage('deploy-release') {
-                steps {
-                    build job: 'Release-Branch/run-all-tests'
-                }
+            steps {
+                build job: 'Release-Branch/run-all-tests'
             }
+
         }
     }
     post {

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -17,7 +17,7 @@
  * language governing permissions and limitations under the License.
  */
 
-@Library('jenkins-lib@develop') _
+@Library(value='jenkins-lib@develop', changelog=false) _
 
 pipeline {
     tools {

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -34,6 +34,9 @@ pipeline {
            steps {
 //               sendNotifications "STARTED"
                script {
+                   dir('RadixCore'){
+                       deleteDir()
+                   }
                    checkoutHelpers.doCheckout("RadixCore")
                }
             }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
                         ).trim()
                         echo tag
 
-                        docker_helpers.manualPushToDockerHub("radixdlt-core", tag)
+                        dockerHelpers.manualPushToDockerHub("radixdlt-core", tag)
                     }
                 }
             }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -64,7 +64,7 @@ pipeline {
                         ).trim()
                         echo tag
 
-                        manualPushToDockerHub("radixdlt-core", tag)
+                        dockerHelpers.manualPushToDockerHub("radixdlt-core", tag)
                     }
                 }
             }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
                         ).trim()
                         echo tag
 
-                        docker.manualPushToDockerHub("radixdlt-core", tag)
+                        docker_helpers.manualPushToDockerHub("radixdlt-core", tag)
                     }
                 }
             }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -1,0 +1,64 @@
+#!/usr/bin/env groovy
+
+#!groovy
+@Library('jenkins-lib@RPNV1-262-Jenkinsfile-setup') _
+
+pipeline {
+    tools {
+        jdk 'open-jdk-11'
+    }
+    options {
+      timeout(time: 20, unit: 'MINUTES')
+    }
+    agent {
+        label 'master'
+    }
+    stages {
+
+        stage('Checkout RadixCore') {
+           environment {
+               BRANCH_CORE = "release/1.0-beta*"
+           }
+           steps {
+
+                   dir('RadixCore'){
+                        deleteDir()
+                   }
+                   dir('RadixCore@tmp'){
+                        deleteDir()
+                   }
+
+
+                checkout([$class: 'GitSCM', branches: [[name: env.BRANCH_CORE],[name: 'refs/tags/1.0-beta.*']],
+                doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', clean: true,
+                relativeTargetDir: 'RadixCore']], submoduleCfg: [],
+                userRemoteConfigs: [[credentialsId: '6271ba56-812d-4c72-a89f-89454ba64f1b', url: 'https://github.com/radixdlt/radixdlt-core.git']],
+                poll: false])
+            }
+        }
+
+        stage('Build and push core image') {
+            steps {
+                dir('RadixCore'){
+                    tag = sh(
+                            script:'''
+                              git describe --abbrev=0 --tags
+                            ''',returnStdout: true
+                            ).trim()
+//                    docker.manualPushToDockerHub("radixdlt-core",tag)
+                }
+            }
+        }
+
+    }
+    post {
+        always {
+            // sendNotifications currentBuild.result
+            dir('RadixCore'){
+                // deleteDir()
+            }
+
+       }
+
+    }
+}

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -52,9 +52,9 @@ pipeline {
                                     branch_commit=`git show-ref refs/remotes/origin/task/RPNV1-262-release-branch-job | cut -d" " -f1`
                                     if [ $tag_commit == $branch_commit ] 
                                     then 
-                                        echo "passed"
+                                        echo "TAG_CREATED"
                                     else 
-                                        echo "failed"
+                                        echo "TAG_NOT_FOUND"
                                     fi
                                 ''', returnStdout: true
                         ).trim()
@@ -68,7 +68,7 @@ pipeline {
         stage('Build and push core image') {
             when {
                 expression {
-                    env.check == "passed"
+                    env.check == "TAG_CREATED"
                 }
             }
             steps {
@@ -86,6 +86,11 @@ pipeline {
 
         }
         stage('Downstream jobs') {
+            when {
+                expression {
+                    env.check == "TAG_NOT_FOUND"
+                }
+            }
             parallel {
                 stage('deploy-release'){
                     steps{

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -46,12 +46,13 @@ pipeline {
             steps {
                 script {
                     dir('RadixCore') {
-                        tag_commit = sh('''
+                        tag_commit = sh(script: '''
                                       git show-ref $(git describe --abbrev=0 --tags) | grep 'refs/tags/' | cut -d" " -f1
                                     ''', returnStdout: true).trim()
-                        branch_commit = sh('''
+                        branch_commit = sh(script: '''
                                         git show-ref $(git rev-parse --abbrev-ref HEAD | sed 's/heads\\///g') | grep 'refs/heads' | cut -d " " -f1
-                                        ''', returnStdout: true)
+                                        ''', returnStdout: true).trim
+
                         echo "Branch commit = ${branch_commit}"
                         echo "Tag commit = ${tag_commit}"
 

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -37,6 +37,7 @@ pipeline {
                 script {
                     tag = sh(
                             script: '''
+                                    git checkout ${BRANCH_NAME}
                                     git describe --abbrev=0 --tags
                                 ''', returnStdout: true
                     ).trim()

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -44,7 +44,7 @@ pipeline {
                         deleteDir()
                    }
 
-
+               sh 'printenv'
                 checkout([
                         $class: 'GitSCM',
                         branches: ["${BRANCH}"],

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -30,20 +30,9 @@ pipeline {
         label 'master'
     }
     stages {
-
         stage('Checkout RadixCore') {
-           environment {
-               BRANCH_CORE = "release/1.0-beta*"
-           }
            steps {
-
-                   dir('RadixCore'){
-                        deleteDir()
-                   }
-                   dir('RadixCore@tmp'){
-                        deleteDir()
-                   }
-
+               sendNotifications "STARTED"
                sh 'printenv'
                 checkout([
                         $class: 'GitSCM',
@@ -77,15 +66,10 @@ pipeline {
                 }
             }
         }
-
     }
     post {
         always {
-            // sendNotifications currentBuild.result
-            dir('RadixCore'){
-                // deleteDir()
-            }
-
+            sendNotifications currentBuild.result
        }
 
     }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -39,13 +39,16 @@ pipeline {
         stage('Build and push core image') {
             steps {
                 dir('RadixCore'){
-                    tag = sh(
-                            script:'''
+                    script {
+                        tag = sh(
+                                script: '''
                               git describe --abbrev=0 --tags
-                            ''',returnStdout: true
-                            ).trim()
-                    echo tag
-                    docker.manualPushToDockerHub("radixdlt-core",tag)
+                            ''', returnStdout: true
+                        ).trim()
+                        echo tag
+
+                        docker.manualPushToDockerHub("radixdlt-core", tag)
+                    }
                 }
             }
         }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
 
         stage('Checkout RadixCore') {
             steps {
-//               sendNotifications "STARTED"
+               sendNotifications "STARTED"
                 script {
                     dir('RadixCore') {
                         deleteDir()
@@ -118,9 +118,9 @@ pipeline {
             }
         }
     }
-//    post {
-//        always {
-////            sendNotifications currentBuild.result
-//        }
-//    }
+    post {
+        always {
+            sendNotifications currentBuild.result
+        }
+    }
 }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -43,10 +43,11 @@ pipeline {
             }
         }
         stage('Check tag and branch have same commit') {
-            script {
-                dir('RadixCore') {
-                    env.check = sh(
-                            script: '''
+            steps{
+                script {
+                    dir('RadixCore') {
+                        env.check = sh(
+                                script: '''
                                     tag_commit=`git show-ref $(git describe --abbrev=0 --tags) | cut -d" " -f1`
                                     branch_commit=`git show-ref refs/remotes/origin/task/RPNV1-262-release-branch-job | cut -d" " -f1`
                                     if [ $tag_commit == $branch_commit ] 
@@ -55,9 +56,10 @@ pipeline {
                                     else 
                                         echo "failed"
                                 ''', returnStdout: true
-                    ).trim()
-                    echo env.check
+                        ).trim()
+                        echo env.check
 
+                    }
                 }
             }
         }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -45,11 +45,19 @@ pipeline {
                    }
 
 
-                checkout([$class: 'GitSCM', branches: [[name: env.BRANCH_CORE],[name: 'refs/tags/1.0-beta.*']],
-                doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', clean: true,
-                relativeTargetDir: 'RadixCore']], submoduleCfg: [],
-                userRemoteConfigs: [[credentialsId: '6271ba56-812d-4c72-a89f-89454ba64f1b', url: 'https://github.com/radixdlt/radixdlt-core.git']],
-                poll: false])
+                checkout([
+                        $class: 'GitSCM',
+                        branches: ["${BRANCH}"],
+                        doGenerateSubmoduleConfigurations: false,
+                        extensions: [
+                                [$class: 'RelativeTargetDirectory', clean: true, relativeTargetDir: 'RadixCore'],
+                                [$class: 'LocalBranch', localBranch: '$BRANCH']
+                        ],
+                        submoduleCfg: [],
+                        userRemoteConfigs: [
+                                [credentialsId: '6271ba56-812d-4c72-a89f-89454ba64f1b', url: 'https://github.com/radixdlt/radixdlt-core.git']
+                        ]
+                ])
             }
         }
 

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -1,6 +1,23 @@
 #!/usr/bin/env groovy
 
-@Library('jenkins-lib@task/RPNV1-262-Jenkinsfile-setup') _
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+@Library('jenkins-lib@RPNV1-262-Jenkinsfile-setup') _
 
 pipeline {
     tools {

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -30,37 +30,65 @@ pipeline {
         label 'master'
     }
     stages {
+
         stage('Checkout RadixCore') {
-           steps {
+            steps {
 //               sendNotifications "STARTED"
-               script {
-                   dir('RadixCore'){
-                       deleteDir()
-                   }
-                   checkoutHelpers.doCheckout("RadixCore")
-               }
+                script {
+                    dir('RadixCore') {
+                        deleteDir()
+                    }
+                    checkoutHelpers.doCheckout("RadixCore")
+                }
+            }
+        }
+        stage('Check tag and branch have same commit') {
+            script {
+                dir('RadixCore') {
+                    env.check = sh(
+                            script: '''
+                                    tag_commit=`git show-ref $(git describe --abbrev=0 --tags) | cut -d" " -f1`
+                                    branch_commit=`git show-ref refs/remotes/origin/task/RPNV1-262-release-branch-job | cut -d" " -f1`
+                                    if [ $tag_commit == $branch_commit ] 
+                                    then 
+                                        echo "passed"
+                                    else 
+                                        echo "failed"
+                                ''', returnStdout: true
+                    ).trim()
+                    echo env.check
+
+                }
             }
         }
 
         stage('Build and push core image') {
-            steps {
-                dir('RadixCore'){
-                    script {
-                        tag = sh(
-                                script: '''
+            when {
+                expression {
+                    env.check == "passed"
+                }
+                steps {
+                    dir('RadixCore') {
+                        script {
+                            tag = sh(
+                                    script: '''
                                     git describe --abbrev=0 --tags
                                 ''', returnStdout: true
-                        ).trim()
-                        dockerHelpers.manualPushToDockerHub("radixdlt-core", tag)
+                            ).trim()
+                            dockerHelpers.manualPushToDockerHub("radixdlt-core", tag)
+                        }
                     }
                 }
             }
         }
         stage('Downstream jobs') {
             steps {
-                build job: 'Release-Branch/deploy-release'
-//            build job: 'Release-Branch/deterministic-simulation-tests'
-                build job: 'Release-Branch/regression-acceptance-tests'
+                parallel {
+                    build job: 'Release-Branch/deploy-release'
+                    build job: 'Release-Branch/docker-continuous-tests'
+                    build job: 'Release-Branch/regression-acceptance-tests'
+                    build job: 'Release-Branch/deterministic-simulation-tests'
+                }
             }
         }
     }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -85,11 +85,17 @@ pipeline {
 
         }
         stage('Downstream jobs') {
-            steps {
-                parallel {
+            parallel {
+                stage('deploy-release'){
                     build job: 'Release-Branch/deploy-release'
+                }
+                stage('docker-continuous-tests'){
                     build job: 'Release-Branch/docker-continuous-tests'
+                }
+                stage('regression-acceptance-tests'){
                     build job: 'Release-Branch/regression-acceptance-tests'
+                }
+                stage('deterministic-simulation-tests'){
                     build job: 'Release-Branch/deterministic-simulation-tests'
                 }
             }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -53,10 +53,12 @@ pipeline {
                 }
             }
         }
-        stage('Deploy image on testnet'){
-            build job: 'Release-Branch/deploy-release'
+        stage('Downstream jobs'){
+            steps{
+                build job: 'Release-Branch/deploy-release'
 //            build job: 'Release-Branch/deterministic-simulation-tests'
-            build job: 'Release-Branch/regression-acceptance-tests'
+                build job: 'Release-Branch/regression-acceptance-tests'
+            }
         }
     }
     post {

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
                         ).trim()
                         echo tag
 
-                        dockerHelpers.manualPushToDockerHub("radixdlt-core", tag)
+                        manualPushToDockerHub("radixdlt-core", tag)
                     }
                 }
             }


### PR DESCRIPTION
These changes are related to below two JIRA tasks . As Release branches keeps changing, we need to setup multibranch job and add a jenkinsfile on the repo. 

This job https://jenkins-preprod.radixdlt.com/job/Release-Branch/job/build-core-multi-branch/ in setup to run for below branch and tag filters

release/1.0-beta* 1.0-beta*

Whenever a new branch/tag matching above is avaliable on github, then jenkin setups a job and run this jenkins file. There is bit of logic to check if the commit of the latest tag and the branch the job is running is same, (which happens when there is tag  added to release branch), then there is jenkins stage that pushes the image. Otherwise, it assumes the release branch has a new commit but has no tag, and just runs the jobs



https://radixdlt.atlassian.net/browse/RPNV1-690
https://radixdlt.atlassian.net/browse/RPNV1-262