### PR TITLE
Implement optional issuance to fixed keys for development universe

### DIFF
--- a/radixdlt/build.gradle
+++ b/radixdlt/build.gradle
@@ -223,7 +223,12 @@ task generateDevUniverse(type: Exec) {
     group = "Execution"
     description = "Generate development universe"
     commandLine "java", "-classpath", sourceSets.main.runtimeClasspath.getAsPath(),
-	    "org.radix.GenerateUniverses", "-t", "development", "-p", "-v", validators, "-j"
+        "org.radix.GenerateUniverses",
+        "--universe-type=development",
+        "--validator-count=${validators}",
+        "--include-private-keys",
+        "--no-json-output",
+        "--issue-default-tokens"
 }
 
 task createGenerateUniversesScripts(type: CreateStartScripts) {


### PR DESCRIPTION
Created as draft, so that merge target can be changed to rc once integration for validator selection merged.