### PR TITLE
Reduce frequency of unnecessary log

### DIFF
--- a/radixdlt/src/main/java/com/radixdlt/DispatcherModule.java
+++ b/radixdlt/src/main/java/com/radixdlt/DispatcherModule.java
@@ -107,8 +107,10 @@ public class DispatcherModule extends AbstractModule {
 	) {
 		EventDispatcher<LocalSyncRequest> envDispatcher = environment.getDispatcher(LocalSyncRequest.class);
 		return req -> {
-			Class<?> callingClass = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE).getCallerClass();
-			logger.info("LOCAL_SYNC_REQUEST dispatched by {}", callingClass);
+			if (logger.isTraceEnabled()) {
+				Class<?> callingClass = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE).getCallerClass();
+				logger.trace("LOCAL_SYNC_REQUEST dispatched by {}", callingClass);
+			}
 
 			if (req.getTargetNodes().contains(self)) {
 				throw new IllegalStateException("Should not be targeting self.");
@@ -249,13 +251,13 @@ public class DispatcherModule extends AbstractModule {
 	) {
 		if (asyncProcessors.isEmpty()) {
 			return timeout -> {
-				logger.warn("LOCAL_TIMEOUT_OCCURRENCE: {}", timeout);
+				logger.info("LOCAL_TIMEOUT_OCCURRENCE: {}", timeout);
 				processors.forEach(e -> e.process(timeout));
 			};
 		} else {
 			EventDispatcher<EpochLocalTimeoutOccurrence> dispatcher = environment.getDispatcher(EpochLocalTimeoutOccurrence.class);
 			return timeout -> {
-				logger.warn("LOCAL_TIMEOUT_OCCURRENCE: {}", timeout);
+				logger.info("LOCAL_TIMEOUT_OCCURRENCE: {}", timeout);
 				dispatcher.dispatch(timeout);
 				processors.forEach(e -> e.process(timeout));
 			};
@@ -311,7 +313,7 @@ public class DispatcherModule extends AbstractModule {
 		final RateLimiter logLimiter = RateLimiter.create(1.0);
 		EventDispatcher<EpochViewUpdate> dispatcher = environment.getDispatcher(EpochViewUpdate.class);
 		return epochViewUpdate -> {
-			Level logLevel = logLimiter.tryAcquire() ? Level.INFO : Level.TRACE;
+			Level logLevel = logLimiter.tryAcquire() ? Level.DEBUG : Level.TRACE;
 			logger.log(logLevel, "NextSyncView: {}", epochViewUpdate);
 			dispatcher.dispatch(epochViewUpdate);
 			processors.forEach(e -> e.process(epochViewUpdate));

--- a/radixdlt/src/main/java/com/radixdlt/consensus/bft/BFTEventPreprocessor.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/bft/BFTEventPreprocessor.java
@@ -100,7 +100,9 @@ public final class BFTEventPreprocessor implements BFTEventProcessor {
 					.forEach(this::processViewCachedEvent);
 			viewQueues.keySet().removeIf(v -> v.lte(viewUpdate.getCurrentView()));
 
-			log.debug("ViewUpdate: Clearing Queues: {}", syncQueues);
+			if (!this.syncQueues.isEmpty()) {
+				log.debug("ViewUpdate: Clearing Queues: {}", syncQueues);
+			}
 			for (SyncQueue queue : syncQueues.getQueues()) {
 				if (clearAndExecute(queue, viewUpdate.getCurrentView().previous())) {
 					queue.pop();

--- a/radixdlt/src/main/java/com/radixdlt/consensus/bft/SyncQueues.java
+++ b/radixdlt/src/main/java/com/radixdlt/consensus/bft/SyncQueues.java
@@ -113,6 +113,10 @@ public final class SyncQueues {
 		return queues.values();
 	}
 
+	public boolean isEmpty() {
+		return this.queues.isEmpty();
+	}
+
 	boolean isEmptyElseAdd(ConsensusEvent event) {
 		return this.getQueue(event.getAuthor()).isEmptyElseAdd(event);
 	}
@@ -135,4 +139,5 @@ public final class SyncQueues {
 		});
 		return String.format("{%s}", joiner);
 	}
+
 }


### PR DESCRIPTION
Reduce the frequency of these logs:
```
2020-12-08T09:12:12,062 [DEBUG/BFTEventPreprocessor/ConsensusRunner] (BFTEventPreprocessor.java:103) - ViewUpdate: Clearing Queues: {}
```

Which are produced at a rate of approximately 250,000/hour or 70/second.