### PR TITLE
Two small changes

### DIFF
--- a/docker/Dockerfile.core
+++ b/docker/Dockerfile.core
@@ -2,7 +2,7 @@ FROM ubuntu:20.04
 MAINTAINER radixdlt <devops@radixdlt.com>
 
 RUN apt-get -y update && \
-    apt-get -y --no-install-recommends install net-tools iptables gettext-base curl tcpdump strace attr software-properties-common openjdk-11-jdk && \
+    apt-get -y --no-install-recommends install net-tools iptables iproute2 gettext-base curl tcpdump strace attr software-properties-common openjdk-11-jdk && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/*
 

--- a/docker/core.yml
+++ b/docker/core.yml
@@ -9,7 +9,7 @@ services:
       RADIXDLT_PACEMAKER_TIMEOUT_MILLIS: 1000
       RADIXDLT_LOG_LEVEL: debug
       RADIXDLT_UNIVERSE: ${RADIXDLT_UNIVERSE}
-      JAVA_OPTS: -server -Xmx512m -Xmx512m -XX:+HeapDumpOnOutOfMemoryError -XX:+AlwaysPreTouch -Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStoreType=jks -Djava.security.egd=file:/dev/urandom -Dcom.sun.management.jmxremote.port=9011 -Dcom.sun.management.jmxremote.rmi.port=9011 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=localhost -agentlib:jdwp=transport=dt_socket,address=50505,suspend=n,server=y
+      JAVA_OPTS: -server -Xmx512m -Xmx512m -XX:+HeapDumpOnOutOfMemoryError -XX:+AlwaysPreTouch -Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStoreType=jks -Djava.security.egd=file:/dev/urandom -Dcom.sun.management.jmxremote.port=9011 -Dcom.sun.management.jmxremote.rmi.port=9011 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=core -agentlib:jdwp=transport=dt_socket,address=50505,suspend=n,server=y
     image: radixdlt/radixdlt-core:develop
     labels:
       com.radixdlt.roles: "core"


### PR DESCRIPTION
Changed `java.rmi.server.hostname` to `core` so that CPU & memory monitoring gets fixed.

Added the iproute2 package, which will install [traffic control](https://manpages.debian.org/unstable/iproute2/tc.8.en.html), needed for some tests.